### PR TITLE
Make parsing and assumptions about UID/RECURRENCE-ID explicit

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ guava = { module = "com.google.guava:guava", version.ref = "guava" }
 ical4j = { module = "org.mnode.ical4j:ical4j", version.ref = "ical4j" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 slf4j-jdk = { module = "org.slf4j:slf4j-jdk14", version.ref = "slf4j" }
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -135,4 +135,5 @@ dependencies {
 
     // unit tests
     testImplementation(libs.junit)
+    testImplementation(libs.mockk)
 }

--- a/lib/src/main/kotlin/at/bitfire/ical4android/AndroidEvent.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/AndroidEvent.kt
@@ -786,7 +786,7 @@ class AndroidEvent(
     private fun buildEvent(recurrence: Event?, builder: CpoBuilder) {
         val event = recurrence ?: requireNotNull(event)
 
-        val dtStart = event.dtStart ?: throw LocalStorageException("Events must have DTSTART")
+        val dtStart = event.dtStart ?: throw InvalidLocalResourceException("Events must have DTSTART")
         val allDay = DateUtils.isDate(dtStart)
 
         // make sure that time zone is supported by Android

--- a/lib/src/main/kotlin/at/bitfire/ical4android/AndroidEvent.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/AndroidEvent.kt
@@ -38,6 +38,7 @@ import at.bitfire.ical4android.util.TimeApiExtensions.toLocalDate
 import at.bitfire.ical4android.util.TimeApiExtensions.toLocalTime
 import at.bitfire.ical4android.util.TimeApiExtensions.toRfc5545Duration
 import at.bitfire.ical4android.util.TimeApiExtensions.toZonedDateTime
+import at.bitfire.synctools.exception.InvalidLocalResourceException
 import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
 import at.bitfire.synctools.storage.CalendarBatchOperation
 import at.bitfire.synctools.storage.LocalStorageException
@@ -215,7 +216,7 @@ class AndroidEvent(
         }
 
         val allDay = (row.getAsInteger(Events.ALL_DAY) ?: 0) != 0
-        val tsStart = row.getAsLong(Events.DTSTART) ?: throw LocalStorageException("Found event without DTSTART")
+        val tsStart = row.getAsLong(Events.DTSTART) ?: throw InvalidLocalResourceException("Found event without DTSTART")
 
         var tsEnd = row.getAsLong(Events.DTEND)
         var duration =   // only use DURATION of DTEND is not defined
@@ -785,7 +786,7 @@ class AndroidEvent(
     private fun buildEvent(recurrence: Event?, builder: CpoBuilder) {
         val event = recurrence ?: requireNotNull(event)
 
-        val dtStart = event.dtStart ?: throw InvalidCalendarException("Events must have DTSTART")
+        val dtStart = event.dtStart ?: throw LocalStorageException("Events must have DTSTART")
         val allDay = DateUtils.isDate(dtStart)
 
         // make sure that time zone is supported by Android

--- a/lib/src/main/kotlin/at/bitfire/ical4android/Event.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/Event.kt
@@ -9,6 +9,7 @@ package at.bitfire.ical4android
 import at.bitfire.ical4android.ICalendar.Companion.CALENDAR_NAME
 import at.bitfire.ical4android.util.DateUtils.isDateTime
 import at.bitfire.ical4android.validation.EventValidator
+import at.bitfire.synctools.exception.InvalidLocalResourceException
 import net.fortuna.ical4j.data.CalendarOutputter
 import net.fortuna.ical4j.data.ParserException
 import net.fortuna.ical4j.model.Calendar
@@ -108,7 +109,7 @@ data class Event(
         ical.properties += Version.VERSION_2_0
         ical.properties += prodId.withUserAgents(userAgents)
 
-        val dtStart = dtStart ?: throw InvalidCalendarException("Won't generate event without start time")
+        val dtStart = dtStart ?: throw InvalidLocalResourceException("Won't generate event without start time")
 
         EventValidator.repair(this)     // repair this event before creating the VEVENT
 

--- a/lib/src/main/kotlin/at/bitfire/ical4android/Event.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/Event.kt
@@ -14,6 +14,7 @@ import at.bitfire.synctools.icalendar.CalendarUidSplitter
 import net.fortuna.ical4j.data.CalendarOutputter
 import net.fortuna.ical4j.data.ParserException
 import net.fortuna.ical4j.model.Calendar
+import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.TextList
@@ -259,8 +260,8 @@ data class Event(
             val ical = fromReader(reader, properties)
 
             // process VEVENTs
-            val splitter = CalendarUidSplitter(ical)
-            val vEventsByUid = splitter.associateEvents()
+            val splitter = CalendarUidSplitter<VEvent>()
+            val vEventsByUid = splitter.associateByUid(ical, Component.VEVENT)
 
             /* Note: There may be UIDs which have only RECURRENCE-ID entries and not a main entry (for instance, a recurring
             event with an exception where the current user has been invited only to this exception. In this case,

--- a/lib/src/main/kotlin/at/bitfire/ical4android/ICalendar.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/ICalendar.kt
@@ -91,6 +91,7 @@ open class ICalendar {
          *
          * @throws InvalidRemoteResourceException when the iCalendar can't be parsed
          */
+        @Deprecated("Use ICalendarParser directly")
         fun fromReader(reader: Reader, properties: MutableMap<String, String>? = null): Calendar {
             logger.fine("Parsing iCalendar stream")
 

--- a/lib/src/main/kotlin/at/bitfire/ical4android/ICalendar.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/ICalendar.kt
@@ -94,7 +94,7 @@ open class ICalendar {
         fun fromReader(reader: Reader, properties: MutableMap<String, String>? = null): Calendar {
             logger.fine("Parsing iCalendar stream")
 
-            val calendar = ICalendarParser(reader).parse()
+            val calendar = ICalendarParser().parse(reader)
 
             // fill calendar properties
             properties?.let {

--- a/lib/src/main/kotlin/at/bitfire/ical4android/ICalendar.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/ICalendar.kt
@@ -9,9 +9,9 @@ package at.bitfire.ical4android
 import at.bitfire.ical4android.ICalendar.Companion.CALENDAR_NAME
 import at.bitfire.ical4android.validation.ICalPreprocessor
 import at.bitfire.synctools.BuildConfig
+import at.bitfire.synctools.exception.InvalidRemoteResourceException
+import at.bitfire.synctools.icalendar.ICalendarParser
 import net.fortuna.ical4j.data.CalendarBuilder
-import net.fortuna.ical4j.data.CalendarParserFactory
-import net.fortuna.ical4j.data.ContentHandlerContext
 import net.fortuna.ical4j.data.ParserException
 import net.fortuna.ical4j.model.Calendar
 import net.fortuna.ical4j.model.ComponentList
@@ -19,7 +19,6 @@ import net.fortuna.ical4j.model.Date
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.PropertyList
-import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import net.fortuna.ical4j.model.component.Daylight
 import net.fortuna.ical4j.model.component.Observance
 import net.fortuna.ical4j.model.component.Standard
@@ -89,35 +88,13 @@ open class ICalendar {
          * @param properties Known iCalendar properties (like [CALENDAR_NAME]) will be put into this map. Key: property name; value: property value
          *
          * @return parsed iCalendar resource
-         * @throws ParserException when the iCalendar can't be parsed
-         * @throws IllegalArgumentException when the iCalendar resource contains an invalid value
+         *
+         * @throws InvalidRemoteResourceException when the iCalendar can't be parsed
          */
         fun fromReader(reader: Reader, properties: MutableMap<String, String>? = null): Calendar {
             logger.fine("Parsing iCalendar stream")
 
-            // preprocess stream to work around some problems that can't be fixed later
-            val preprocessed = ICalPreprocessor.preprocessStream(reader)
-
-            // parse stream
-            val calendar: Calendar
-            try {
-                calendar = CalendarBuilder(
-                    CalendarParserFactory.getInstance().get(),
-                    ContentHandlerContext().withSupressInvalidProperties(true),
-                    TimeZoneRegistryFactory.getInstance().createRegistry()      // AndroidCompatTimeZoneRegistry
-                ).build(preprocessed)
-            } catch(e: ParserException) {
-                throw InvalidCalendarException("Couldn't parse iCalendar", e)
-            } catch(e: IllegalArgumentException) {
-                throw InvalidCalendarException("iCalendar contains invalid value", e)
-            }
-
-            // apply ICalPreprocessor for increased compatibility
-            try {
-                ICalPreprocessor.preprocessCalendar(calendar)
-            } catch (e: Exception) {
-                logger.log(Level.WARNING, "Couldn't pre-process iCalendar", e)
-            }
+            val calendar = ICalendarParser(reader).parse()
 
             // fill calendar properties
             properties?.let {

--- a/lib/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
@@ -14,13 +14,13 @@ import android.os.ParcelFileDescriptor
 import android.util.Base64
 import at.bitfire.ical4android.ICalendar.Companion.withUserAgents
 import at.bitfire.ical4android.util.MiscUtils.toValues
+import at.bitfire.synctools.exception.InvalidRemoteResourceException
 import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.storage.JtxBatchOperation
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.JtxICalObject.TZ_ALLDAY
 import at.techbee.jtx.JtxContract.asSyncAdapter
 import net.fortuna.ical4j.data.CalendarOutputter
-import net.fortuna.ical4j.data.ParserException
 import net.fortuna.ical4j.model.Calendar
 import net.fortuna.ical4j.model.ComponentList
 import net.fortuna.ical4j.model.Date
@@ -283,8 +283,7 @@ open class JtxICalObject(
          *
          * @return array of filled [JtxICalObject] data objects (may have size 0)
          *
-         * @throws ParserException when the iCalendar can't be parsed
-         * @throws IllegalArgumentException when the iCalendar resource contains an invalid value
+         * @throws InvalidRemoteResourceException when the iCalendar can't be parsed
          * @throws IOException on I/O errors
          */
         fun fromReader(

--- a/lib/src/main/kotlin/at/bitfire/ical4android/Task.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/Task.kt
@@ -8,8 +8,8 @@ package at.bitfire.ical4android
 
 import androidx.annotation.IntRange
 import at.bitfire.ical4android.util.DateUtils
+import at.bitfire.synctools.exception.InvalidRemoteResourceException
 import net.fortuna.ical4j.data.CalendarOutputter
-import net.fortuna.ical4j.data.ParserException
 import net.fortuna.ical4j.model.Calendar
 import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.DateTime
@@ -106,8 +106,7 @@ data class Task(
          *
          * @return array of filled [Task] data objects (may have size 0)
          *
-         * @throws ParserException when the iCalendar can't be parsed
-         * @throws IllegalArgumentException when the iCalendar resource contains an invalid value
+         * @throws InvalidRemoteResourceException when the iCalendar can't be parsed
          * @throws IOException on I/O errors
          */
         fun tasksFromReader(reader: Reader): List<Task> {

--- a/lib/src/main/kotlin/at/bitfire/synctools/exception/InvalidLocalResourceException.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/exception/InvalidLocalResourceException.kt
@@ -1,0 +1,17 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.exception
+
+/**
+ * Represents an invalid local resource (for instance, an Android event).
+ */
+class InvalidLocalResourceException: InvalidResourceException {
+
+    constructor(message: String): super(message)
+    constructor(message: String, ex: Throwable): super(message, ex)
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/exception/InvalidRemoteResourceException.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/exception/InvalidRemoteResourceException.kt
@@ -1,0 +1,17 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.exception
+
+/**
+ * Represents an invalid remote resource (for instance, a calendar object resource).
+ */
+class InvalidRemoteResourceException: Exception {
+
+    constructor(message: String): super(message)
+    constructor(message: String, ex: Throwable): super(message, ex)
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/exception/InvalidRemoteResourceException.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/exception/InvalidRemoteResourceException.kt
@@ -9,7 +9,7 @@ package at.bitfire.synctools.exception
 /**
  * Represents an invalid remote resource (for instance, a calendar object resource).
  */
-class InvalidRemoteResourceException: Exception {
+class InvalidRemoteResourceException: InvalidResourceException {
 
     constructor(message: String): super(message)
     constructor(message: String, ex: Throwable): super(message, ex)

--- a/lib/src/main/kotlin/at/bitfire/synctools/exception/InvalidResourceException.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/exception/InvalidResourceException.kt
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-package at.bitfire.ical4android
+package at.bitfire.synctools.exception
 
-class InvalidCalendarException: Exception {
+/**
+ * Represents an invalid resource.
+ */
+abstract class InvalidResourceException: Exception {
 
     constructor(message: String): super(message)
     constructor(message: String, ex: Throwable): super(message, ex)

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/AssociatedComponents.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/AssociatedComponents.kt
@@ -6,21 +6,22 @@
 
 package at.bitfire.synctools.icalendar
 
+import net.fortuna.ical4j.model.component.CalendarComponent
 import net.fortuna.ical4j.model.component.VEvent
 
 /**
- * @param main          main VEVent (with UID, without RECURRENCE-ID), may be `null` if only exceptions are present
- * @param exceptions    exceptions (each with UID and RECURRENCE-ID); UID must be
- *   1. the same as the UID of [main] (if present),
+ * @param main          main component (with or without UID, but without RECURRENCE-ID), may be `null` if only exceptions are present
+ * @param exceptions    exceptions (each without RECURRENCE-ID); UID must be
+ *   1. the same as the UID of [main],
  *   2. the same for all exceptions.
  *
  * If no [main] is present, [exceptions] must not be empty.
  *
  * @throws IllegalArgumentException   when the constraints above are violated
  */
-data class AssociatedVEvents(
-    val main: VEvent?,
-    val exceptions: List<VEvent>
+data class AssociatedComponents<T: CalendarComponent>(
+    val main: T?,
+    val exceptions: List<T>
 ) {
 
     init {
@@ -35,8 +36,6 @@ data class AssociatedVEvents(
     private fun validate() {
         val mainUid =
             if (main != null) {
-                if (main.uid == null)
-                    throw IllegalArgumentException("Main event must have an UID")
                 if (main.recurrenceId != null)
                     throw IllegalArgumentException("Main event must not have a RECURRENCE-ID")
 
@@ -57,8 +56,10 @@ data class AssociatedVEvents(
             } else
                 null
 
-        if (mainUid != null && exceptionsUid != null && exceptionsUid != mainUid)
+        if (exceptions.isNotEmpty() && exceptionsUid != mainUid)
             throw IllegalArgumentException("Exceptions must have the same UID as the main event")
     }
 
 }
+
+typealias AssociatedEvents = AssociatedComponents<VEvent>

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/AssociatedComponents.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/AssociatedComponents.kt
@@ -56,7 +56,7 @@ data class AssociatedComponents<T: CalendarComponent>(
             } else
                 null
 
-        if (exceptions.isNotEmpty() && exceptionsUid != mainUid)
+        if (main != null && exceptions.isNotEmpty() && exceptionsUid != mainUid)
             throw IllegalArgumentException("Exceptions must have the same UID as the main event")
     }
 

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/AssociatedComponents.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/AssociatedComponents.kt
@@ -10,6 +10,16 @@ import net.fortuna.ical4j.model.component.CalendarComponent
 import net.fortuna.ical4j.model.component.VEvent
 
 /**
+ * Represents a set of components (like VEVENT) stored in a calendar object resource as defined
+ * in RFC 4791 section 4.1. It consists of
+ *
+ * - an (optional) main component,
+ * - optional exceptions of this main component.
+ *
+ * Note: It's possible and valid that there's no main component, but only exceptions, for instance
+ * when the user has been invited to a specific instance (= exception) of a recurring event, but
+ * not to the event as a whole (→ main event is unknown / not present).
+ *
  * @param main          main component (with or without UID, but without RECURRENCE-ID), may be `null` if only exceptions are present
  * @param exceptions    exceptions (each without RECURRENCE-ID); UID must be
  *   1. the same as the UID of [main],
@@ -34,6 +44,9 @@ data class AssociatedComponents<T: CalendarComponent>(
      * @throws IllegalArgumentException     if [main] and/or [exceptions] UIDs don't match
      */
     private fun validate() {
+        if (main == null && exceptions.isEmpty())
+            throw IllegalArgumentException("At least one component is required")
+
         val mainUid =
             if (main != null) {
                 if (main.recurrenceId != null)

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/AssociatedVEvents.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/AssociatedVEvents.kt
@@ -1,0 +1,64 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.icalendar
+
+import net.fortuna.ical4j.model.component.VEvent
+
+/**
+ * @param main          main VEVent (with UID, without RECURRENCE-ID), may be `null` if only exceptions are present
+ * @param exceptions    exceptions (each with UID and RECURRENCE-ID); UID must be
+ *   1. the same as the UID of [main] (if present),
+ *   2. the same for all exceptions.
+ *
+ * If no [main] is present, [exceptions] must not be empty.
+ *
+ * @throws IllegalArgumentException   when the constraints above are violated
+ */
+data class AssociatedVEvents(
+    val main: VEvent?,
+    val exceptions: List<VEvent>
+) {
+
+    init {
+        validate()
+    }
+
+    /**
+     * Validates the requirements of [main] and [exceptions] UIDs.
+     *
+     * @throws IllegalArgumentException     if [main] and/or [exceptions] UIDs don't match
+     */
+    private fun validate() {
+        val mainUid =
+            if (main != null) {
+                if (main.uid == null)
+                    throw IllegalArgumentException("Main event must have an UID")
+                if (main.recurrenceId != null)
+                    throw IllegalArgumentException("Main event must not have a RECURRENCE-ID")
+
+                main.uid
+            }
+            else
+                null
+
+        val exceptionsUid =
+            if (exceptions.isNotEmpty()) {
+                if (exceptions.any { it.recurrenceId == null } )
+                    throw IllegalArgumentException("Exceptions must have RECURRENCE-ID")
+
+                val firstExceptionUid = exceptions.first().uid
+                if (exceptions.any { it.uid != firstExceptionUid })
+                    throw IllegalArgumentException("Exceptions must not have different UIDs")
+                firstExceptionUid
+            } else
+                null
+
+        if (mainUid != null && exceptionsUid != null && exceptionsUid != mainUid)
+            throw IllegalArgumentException("Exceptions must have the same UID as the main event")
+    }
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitter.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitter.kt
@@ -1,0 +1,58 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.icalendar
+
+import net.fortuna.ical4j.model.Calendar
+import net.fortuna.ical4j.model.Component
+import net.fortuna.ical4j.model.component.VEvent
+
+/**
+ * Splits iCalendar components by UID.
+ */
+class CalendarUidSplitter(
+    private val calendar: Calendar
+) {
+
+    fun associateEvents(): Map<String?, AssociatedVEvents> {
+        val allVEvents = calendar.getComponents<VEvent>(Component.VEVENT).toMutableList()
+
+        // Note: UID is REQUIRED for events in RFC 5545 section 3.6.1, but optional in RFC 2445 section 4.6.1,
+        // so it's possible that the Uid is null.
+        val byUid: Map<String?, List<VEvent>> = allVEvents
+            .groupBy { it.uid?.value }
+            .mapValues { filterBySequence(it.value) }
+
+        val result = mutableMapOf<String?, AssociatedVEvents>()
+        for ((uid, vEventsWithUid) in byUid) {
+            val mainVEvent = vEventsWithUid.last { it.recurrenceId == null }
+            val exceptions = vEventsWithUid.filter { it.recurrenceId != null }
+            result[uid] = AssociatedVEvents(mainVEvent, exceptions)
+        }
+
+        return result
+    }
+
+    /**
+     * Keeps only the events with the highest SEQUENCE (per RECURRENCE-ID).
+     *
+     * @param events    list of VEVENTs with the same UID, but different RECURRENCE-IDs and SEQUENCEs
+     *
+     * @return same as input list, but each RECURRENCE-ID event only with the highest SEQUENCE
+     */
+    private fun filterBySequence(events: List<VEvent>): List<VEvent> {
+        // group by RECURRENCE-ID (may be null)
+        val byRecurId = events.groupBy { it.recurrenceId?.value }.values
+
+        // for every RECURRENCE-ID: keep only event with highest sequence
+        val latest = byRecurId.map { sameUidAndRecurId ->
+            sameUidAndRecurId.maxBy { it.sequence?.sequenceNo ?: 0 }
+        }
+
+        return latest
+    }
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarParser.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarParser.kt
@@ -27,7 +27,7 @@ class ICalendarParser {
         get() = Logger.getLogger(javaClass.name)
 
     /**
-     * Parses the given iCalendar and applies some error correction:
+     * Parses the given iCalendar as lenient as possible and applies some error correction:
      *
      * 1. The input stream from is preprocessed with [ICalPreprocessor.preprocessStream].
      * 2. The parsed calendar is preprocessed with [ICalPreprocessor.preprocessCalendar].

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarParser.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarParser.kt
@@ -21,9 +21,7 @@ import java.util.logging.Logger
 /**
  * Custom iCalendar parser that applies error correction using [ICalPreprocessor].
  */
-class ICalendarParser(
-    private val reader: Reader
-) {
+class ICalendarParser {
 
     private val logger
         get() = Logger.getLogger(javaClass.name)
@@ -34,9 +32,9 @@ class ICalendarParser(
      * 1. The input stream from is preprocessed with [ICalPreprocessor.preprocessStream].
      * 2. The parsed calendar is preprocessed with [ICalPreprocessor.preprocessCalendar].
      *
-     * @throws InvalidRemoteResourceException   when the resource is invalid
+     * @throws InvalidRemoteResourceException   when the resource is can't be parsed
      */
-    fun parse(): Calendar {
+    fun parse(reader: Reader): Calendar {
         // preprocess stream to work around problems that prevent parsing and thus can't be fixed later
         val preprocessed = ICalPreprocessor.preprocessStream(reader)
 

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarParser.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarParser.kt
@@ -1,0 +1,67 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.icalendar
+
+import at.bitfire.ical4android.validation.ICalPreprocessor
+import at.bitfire.synctools.exception.InvalidRemoteResourceException
+import net.fortuna.ical4j.data.CalendarBuilder
+import net.fortuna.ical4j.data.CalendarParserFactory
+import net.fortuna.ical4j.data.ContentHandlerContext
+import net.fortuna.ical4j.data.ParserException
+import net.fortuna.ical4j.model.Calendar
+import net.fortuna.ical4j.model.TimeZoneRegistryFactory
+import java.io.Reader
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Custom iCalendar parser that applies error correction using [ICalPreprocessor].
+ */
+class ICalendarParser(
+    private val reader: Reader
+) {
+
+    private val logger
+        get() = Logger.getLogger(javaClass.name)
+
+    /**
+     * Parses the given iCalendar and applies some error correction:
+     *
+     * 1. The input stream from is preprocessed with [ICalPreprocessor.preprocessStream].
+     * 2. The parsed calendar is preprocessed with [ICalPreprocessor.preprocessCalendar].
+     *
+     * @throws InvalidRemoteResourceException   when the resource is invalid
+     */
+    fun parse(): Calendar {
+        // preprocess stream to work around problems that prevent parsing and thus can't be fixed later
+        val preprocessed = ICalPreprocessor.preprocessStream(reader)
+
+        // parse stream, ignoring invalid properties (if possible)
+        val calendar: Calendar
+        try {
+            calendar = CalendarBuilder(
+                /* parser = */ CalendarParserFactory.getInstance().get(),
+                /* contentHandlerContext = */ ContentHandlerContext().withSupressInvalidProperties(/* supressInvalidProperties = */ true),
+                /* tzRegistry = */ TimeZoneRegistryFactory.getInstance().createRegistry()      // AndroidCompatTimeZoneRegistry
+            ).build(preprocessed)
+        } catch(e: ParserException) {
+            throw InvalidRemoteResourceException("Couldn't parse iCalendar", e)
+        } catch(e: IllegalArgumentException) {
+            throw InvalidRemoteResourceException("iCalendar contains invalid value", e)
+        }
+
+        // Pre-process calendar for increased compatibility (fixes some common errors)
+        try {
+            ICalPreprocessor.preprocessCalendar(calendar)
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Couldn't pre-process iCalendar", e)
+        }
+
+        return calendar
+    }
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/Ical4jHelpers.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/Ical4jHelpers.kt
@@ -1,0 +1,36 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.icalendar
+
+import net.fortuna.ical4j.model.ComponentList
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.PropertyList
+import net.fortuna.ical4j.model.component.CalendarComponent
+import net.fortuna.ical4j.model.property.RecurrenceId
+import net.fortuna.ical4j.model.property.Sequence
+import net.fortuna.ical4j.model.property.Uid
+
+
+fun<T: CalendarComponent> componentListOf(vararg components: T) =
+    ComponentList<CalendarComponent>().apply {
+        addAll(components)
+    }
+
+fun propertyListOf(vararg properties: Property) =
+    PropertyList<Property>().apply {
+        addAll(properties)
+    }
+
+
+val CalendarComponent.uid: Uid?
+    get() = getProperty(Property.UID)
+
+val CalendarComponent.recurrenceId: RecurrenceId?
+    get() = getProperty(Property.RECURRENCE_ID)
+
+val CalendarComponent.sequence: Sequence?
+    get() = getProperty(Property.SEQUENCE)

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/AssociatedComponentsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/AssociatedComponentsTest.kt
@@ -14,7 +14,7 @@ import org.junit.Test
 
 class AssociatedComponentsTest {
 
-    @Test
+    @Test(expected = IllegalArgumentException::class)
     fun testEmpty() {
         AssociatedEvents(null, emptyList())
     }

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/AssociatedComponentsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/AssociatedComponentsTest.kt
@@ -1,0 +1,79 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.icalendar
+
+import net.fortuna.ical4j.model.Date
+import net.fortuna.ical4j.model.component.VEvent
+import net.fortuna.ical4j.model.property.RecurrenceId
+import net.fortuna.ical4j.model.property.Uid
+import org.junit.Test
+
+class AssociatedComponentsTest {
+
+    @Test
+    fun testEmpty() {
+        AssociatedEvents(null, emptyList())
+    }
+
+    @Test
+    fun testOnlyExceptions_UidNull() {
+        AssociatedEvents(null, listOf(
+            VEvent(propertyListOf(
+                RecurrenceId(Date("20250629"))
+            ))
+        ))
+    }
+
+    @Test
+    fun testOnlyExceptions_UidNotNull() {
+        AssociatedEvents(null, listOf(
+            VEvent(propertyListOf(
+                Uid("test1"),
+                RecurrenceId(Date("20250629"))
+            ))
+        ))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testOnlyExceptions_UidNotIdentical() {
+        AssociatedEvents(null, listOf(
+            VEvent(propertyListOf(
+                RecurrenceId(Date("20250629"))
+            )),
+            VEvent(propertyListOf(
+                Uid("test1"),
+                RecurrenceId(Date("20250630"))
+            ))
+        ))
+    }
+
+    @Test
+    fun testOnlyMain_NoUid() {
+        AssociatedEvents(VEvent(), emptyList())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testOnlyMain_RecurId() {
+        AssociatedEvents(VEvent(propertyListOf(
+            RecurrenceId(Date("20250629"))
+        )), emptyList())
+    }
+
+    @Test
+    fun testOnlyMain_Uid() {
+        AssociatedEvents(VEvent(propertyListOf(Uid("test1"))), emptyList())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testOnlyMain_UidAndRecurId() {
+        AssociatedEvents(VEvent(propertyListOf(
+            Uid("test1"),
+            RecurrenceId(Date("20250629"))
+        )), emptyList())
+    }
+
+}

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitterTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitterTest.kt
@@ -1,0 +1,180 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.icalendar
+
+import net.fortuna.ical4j.model.Calendar
+import net.fortuna.ical4j.model.Component
+import net.fortuna.ical4j.model.ComponentList
+import net.fortuna.ical4j.model.Date
+import net.fortuna.ical4j.model.component.VEvent
+import net.fortuna.ical4j.model.property.RecurrenceId
+import net.fortuna.ical4j.model.property.Sequence
+import net.fortuna.ical4j.model.property.Uid
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CalendarUidSplitterTest {
+
+    @Test
+    fun testAssociatedVEventsByUid_Empty() {
+        val calendar = Calendar(ComponentList())
+        val result = CalendarUidSplitter<VEvent>().associateByUid(calendar, Component.VEVENT)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun testAssociatedVEventsByUid_ExceptionOnly_NoUid() {
+        val exception = VEvent(propertyListOf(
+            RecurrenceId("20250629T000000Z")
+        ))
+        val calendar = Calendar(componentListOf(exception))
+        val result = CalendarUidSplitter<VEvent>().associateByUid(calendar, Component.VEVENT)
+        assertEquals(
+            mapOf(
+                null to AssociatedEvents(null, listOf(exception))
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun testAssociatedVEventsByUid_MainOnly_NoUid() {
+        val mainEvent = VEvent()
+        val calendar = Calendar(componentListOf(mainEvent))
+        val result = CalendarUidSplitter<VEvent>().associateByUid(calendar, Component.VEVENT)
+        assertEquals(
+            mapOf(
+                null to AssociatedEvents(mainEvent, emptyList())
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun testAssociatedVEventsByUid_MainOnly_WithUid() {
+        val mainEvent = VEvent(propertyListOf(
+            Uid("main")
+        ))
+        val calendar = Calendar(componentListOf(mainEvent))
+        val result = CalendarUidSplitter<VEvent>().associateByUid(calendar, Component.VEVENT)
+        assertEquals(
+            mapOf(
+                "main" to AssociatedEvents(mainEvent, emptyList())
+            ),
+            result
+        )
+    }
+
+
+    @Test
+    fun testFilterBySequence_Empty() {
+        val result = CalendarUidSplitter<VEvent>().filterBySequence(emptyList())
+        assertEquals(emptyList<VEvent>(), result)
+    }
+
+    @Test
+    fun testFilterBySequence_MainAndExceptions_MultipleSequences() {
+        val mainEvent1a = VEvent(propertyListOf(Sequence(1)))
+        val mainEvent1b = VEvent(propertyListOf(Sequence(2)))
+        val exception1a = VEvent(propertyListOf(
+            RecurrenceId("20250629T000000Z"),
+            Sequence(1)
+        ))
+        val exception1b = VEvent(propertyListOf(
+            RecurrenceId("20250629T000000Z"),
+            Sequence(2)
+        ))
+        val exception1c = VEvent(propertyListOf(
+            RecurrenceId("20250629T000000Z"),
+            Sequence(3)
+        ))
+        val exception2a = VEvent(propertyListOf(
+            RecurrenceId(Date("20250629"))
+            // Sequence(0)
+        ))
+        val exception2b = VEvent(propertyListOf(
+            RecurrenceId(Date("20250629")),
+            Sequence(1)
+        ))
+        val result = CalendarUidSplitter<VEvent>().filterBySequence(
+            listOf(mainEvent1a, mainEvent1b, exception1a, exception1c, exception1b, exception2a, exception2b)
+        )
+        assertEquals(listOf(mainEvent1b, exception1c, exception2b), result)
+    }
+
+    @Test
+    fun testFilterBySequence_MainAndExceptions_SingleSequence() {
+        val mainEvent = VEvent(propertyListOf(Sequence(1)))
+        val exception1 = VEvent(propertyListOf(
+            RecurrenceId("20250629T000000Z"),
+            Sequence(1)
+        ))
+        val exception2 = VEvent(propertyListOf(
+            RecurrenceId(Date("20250629"))
+            // Sequence(0)
+        ))
+        val result = CalendarUidSplitter<VEvent>().filterBySequence(
+            listOf(mainEvent, exception1, exception2)
+        )
+        assertEquals(listOf(mainEvent, exception1, exception2), result)
+    }
+
+    @Test
+    fun testFilterBySequence_OnlyException_SingleSequence() {
+        val exception = VEvent(propertyListOf(
+            RecurrenceId("20250629T000000Z")
+        ))
+        val result = CalendarUidSplitter<VEvent>().filterBySequence(listOf(exception))
+        assertEquals(listOf(exception), result)
+    }
+
+    @Test
+    fun testFilterBySequence_OnlyExceptions_MultipleSequences() {
+        val exception1a = VEvent(propertyListOf(
+            RecurrenceId("20250629T000000Z"),
+            Sequence(1)
+        ))
+        val exception1b = VEvent(propertyListOf(
+            RecurrenceId("20250629T000000Z"),
+            Sequence(2)
+        ))
+        val exception1c = VEvent(propertyListOf(
+            RecurrenceId("20250629T000000Z"),
+            Sequence(3)
+        ))
+        val exception2a = VEvent(propertyListOf(
+            RecurrenceId(Date("20250629"))
+            // Sequence(0)
+        ))
+        val exception2b = VEvent(propertyListOf(
+            RecurrenceId(Date("20250629")),
+            Sequence(1)
+        ))
+        val result = CalendarUidSplitter<VEvent>().filterBySequence(
+            listOf(exception1a, exception1c, exception1b, exception2a, exception2b)
+        )
+        assertEquals(listOf(exception1c, exception2b), result)
+    }
+
+    @Test
+    fun testFilterBySequence_OnlyMain_SingleSequence() {
+        val mainEvent = VEvent()
+        val result = CalendarUidSplitter<VEvent>().filterBySequence(listOf(mainEvent))
+        assertEquals(listOf(mainEvent), result)
+    }
+
+    @Test
+    fun testFilterBySequence_OnlyMain_MultipleSequences() {
+        val mainEvent1a = VEvent(propertyListOf(Sequence(1)))
+        val mainEvent1b = VEvent(propertyListOf(Sequence(2)))
+        val mainEvent1c = VEvent(propertyListOf(Sequence(2)))
+        val result = CalendarUidSplitter<VEvent>().filterBySequence(listOf(mainEvent1a, mainEvent1c, mainEvent1b))
+        assertEquals(listOf(mainEvent1c), result)
+    }
+
+}

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarParserTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarParserTest.kt
@@ -1,0 +1,10 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.icalendar
+
+class ICalendarParserTest {
+}

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarParserTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarParserTest.kt
@@ -21,7 +21,7 @@ class ICalendarParserTest {
     val mockkRule = MockKRule(this)
 
     @Test
-    fun `parse() applies pre-processing`() {
+    fun testParse_AppliesPreProcessing() {
         mockkObject(ICalPreprocessor)
 
         val reader = StringReader(
@@ -42,7 +42,7 @@ class ICalendarParserTest {
     }
 
     @Test
-    fun `parse() suppresses invalid properties`() {
+    fun testParse_SuppressesInvalidProperties() {
         val reader = StringReader(
             "BEGIN:VCALENDAR\r\n" +
                     "BEGIN:VEVENT\r\n" +
@@ -54,7 +54,7 @@ class ICalendarParserTest {
     }
 
     @Test(expected = InvalidRemoteResourceException::class)
-    fun `parse() throws exception on invalid input`() {
+    fun testParse_ThrowsExceptionOnInvalidInput() {
         val reader = StringReader("invalid")
         ICalendarParser().parse(reader)
     }


### PR DESCRIPTION
Currently iCalendar parsing and UID/RECURRENCE-ID splitting is done in the `Event` data class, where it does not belong to. This PR

- makes iCalendar parsing explicit and moves it to `ICalendarParser` (+ tests),
- makes UID/RECURRENCE-ID splitting explicit and moves it to `CalendarUidSplitter` (+ tests),
- introduces `AssociatedComponents` to associate a main event and its exceptions (+ tests).

There's a FIXME in the code, but it keeps current behavior and fixing that is not in the scope of this PR. I just added the comment to mark that code as bad.

CC @sunkup: Please have a look and comment especially if the "whole thing" that it does is unclear. I tried to add as good KDoc as possible. I however understand that it's hard to review this PR when its taken out of the whole refactoring context.