### PR TITLE
[CI] Move Android lint task to other Android task

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,15 +45,13 @@ jobs:
           cache-encryption-key: ${{ secrets.gradle_encryption_key }}
           cache-read-only: true
 
-      - name: Run lint
-        run: ./gradlew --build-cache --configuration-cache lintDebug
       - name: Run unit tests
         run: ./gradlew --build-cache --configuration-cache testDebugUnitTest
 
   test_on_emulator:
     needs: compile
     if: ${{ !cancelled() }}     # even if compile didn't run (because not on main branch)
-    name: Instrumented tests
+    name: Lint / Instrumented tests
     runs-on: ubuntu-latest
     steps:
       - uses: gradle/actions/setup-gradle@v4
@@ -65,6 +63,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+
+      - name: Run lint
+        run: ./gradlew --build-cache --configuration-cache lintDebug
 
       - name: Enable KVM group perms
         run: |


### PR DESCRIPTION
Because lint depends on Android tasks, so no duplicate Android task calculations (less CPU usage overall)