### PR TITLE
[Dependabot] Update dependency ignore pattern for ical4j

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,5 @@ updates:
       lib-dependencies:
         patterns: ["*"]
     ignore:
-      - dependency-name: "ical4j"
+      - dependency-name: "org.mnode.ical4j:ical4j"
         versions: ["4.x"]


### PR DESCRIPTION
It seems that the version.ref can't be used in the ignore pattern, so use the format mentioned here: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#dependency-name-ignore