### PR TITLE
Fix OOM issues with super large iCalendar files

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/icalendar/validation/ICalPreprocessorInstrumentedTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/icalendar/validation/ICalPreprocessorInstrumentedTest.kt
@@ -1,0 +1,94 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.icalendar.validation
+
+import org.junit.Test
+import java.io.Reader
+import java.util.UUID
+
+class ICalPreprocessorInstrumentedTest {
+
+    class VCalendarReaderGenerator(val eventCount: Int = Int.MAX_VALUE) : Reader() {
+        private var stage = 0 // 0 = header, 1 = events, 2 = footer, 3 = done
+        private var eventIdx = 0
+        private var current: String? = null
+        private var pos = 0
+
+        override fun reset() {
+            stage = 0
+            eventIdx = 0
+            current = null
+            pos = 0
+        }
+
+        override fun read(cbuf: CharArray, off: Int, len: Int): Int {
+            var charsRead = 0
+            while (charsRead < len) {
+                if (current == null || pos >= current!!.length) {
+                    current = when (stage) {
+                        0 -> {
+                            stage = 1
+                            """
+                        BEGIN:VCALENDAR
+                        PRODID:-//xyz Corp//NONSGML PDA Calendar Version 1.0//EN
+                        VERSION:2.0
+                        """.trimIndent() + "\n"
+                        }
+                        1 -> {
+                            if (eventIdx < eventCount) {
+                                val event = """
+                                BEGIN:VEVENT
+                                DTSTAMP:19960704T120000Z
+                                UID:${UUID.randomUUID()}
+                                ORGANIZER:mailto:jsmith@example.com
+                                DTSTART:19960918T143000Z
+                                DTEND:19960920T220000Z
+                                STATUS:CONFIRMED
+                                CATEGORIES:CONFERENCE
+                                SUMMARY:Event $eventIdx
+                                DESCRIPTION:Event $eventIdx description
+                                END:VEVENT
+                            """.trimIndent() + "\n"
+                                eventIdx++
+                                event
+                            } else {
+                                stage = 2
+                                null
+                            }
+                        }
+                        2 -> {
+                            stage = 3
+                            "END:VCALENDAR\n"
+                        }
+                        else -> return if (charsRead == 0) -1 else charsRead
+                    }
+                    pos = 0
+                    if (current == null) continue // move to next stage
+                }
+                val charsLeft = current!!.length - pos
+                val toRead = minOf(len - charsRead, charsLeft)
+                current!!.toCharArray(pos, pos + toRead).copyInto(cbuf, off + charsRead)
+                pos += toRead
+                charsRead += toRead
+            }
+            return charsRead
+        }
+
+        override fun close() {
+            // No resources to release
+            current = null
+        }
+    }
+
+    @Test
+    fun testParse_SuperLargeFiles() {
+        val preprocessor = ICalPreprocessor()
+        val reader = VCalendarReaderGenerator()
+        preprocessor.preprocessStream(reader)
+        // no exception called
+    }
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidDayOffsetPreprocessor.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidDayOffsetPreprocessor.kt
@@ -10,7 +10,7 @@ package at.bitfire.synctools.icalendar.validation
  * Fixes durations with day offsets with the 'T' prefix.
  * See also https://github.com/bitfireAT/ical4android/issues/77
  */
-class FixInvalidDayOffsetPreprocessor : StreamPreprocessor() {
+class FixInvalidDayOffsetPreprocessor : StreamPreprocessor {
 
     override fun regexpForProblem() = Regex(
         // Examples:

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidUtcOffsetPreprocessor.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidUtcOffsetPreprocessor.kt
@@ -16,7 +16,7 @@ import java.util.logging.Logger
  * Rewrites values of all TZOFFSETFROM and TZOFFSETTO properties which match [TZOFFSET_REGEXP]
  * so that an hour value of 00 is inserted.
  */
-class FixInvalidUtcOffsetPreprocessor: StreamPreprocessor() {
+class FixInvalidUtcOffsetPreprocessor: StreamPreprocessor {
 
     private val logger
         get() = Logger.getLogger(javaClass.name)

--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/validation/StreamPreprocessor.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/validation/StreamPreprocessor.kt
@@ -6,51 +6,18 @@
 
 package at.bitfire.synctools.icalendar.validation
 
-import java.io.IOException
-import java.io.Reader
-import java.io.StringReader
-import java.util.Scanner
+interface StreamPreprocessor {
 
-abstract class StreamPreprocessor {
-
-    abstract fun regexpForProblem(): Regex?
+    fun regexpForProblem(): Regex?
 
     /**
      * Fixes an iCalendar string.
+     * The icalendar may not be complete, but just a chunk.
+     * Lines won't be incomplete.
      *
      * @param original The complete iCalendar string
      * @return The complete iCalendar string, but fixed
      */
-    abstract fun fixString(original: String): String
-
-    fun preprocess(reader: Reader): Reader {
-        var result: String? = null
-
-        val resetSupported = try {
-            reader.reset()
-            true
-        } catch(_: IOException) {
-            false
-        }
-
-        if (resetSupported) {
-            val regex = regexpForProblem()
-            // reset is supported, no need to copy the whole stream to another String (unless we have to fix the TZOFFSET)
-            if (regex == null || Scanner(reader).findWithinHorizon(regex.toPattern(), 0) != null) {
-                reader.reset()
-                result = fixString(reader.readText())
-            }
-        } else
-            // reset not supported, always generate a new String that will be returned
-            result = fixString(reader.readText())
-
-        if (result != null)
-            // modified or reset not supported, return new stream
-            return StringReader(result)
-
-        // not modified, return original iCalendar
-        reader.reset()
-        return reader
-    }
+    fun fixString(original: String): String
 
 }

--- a/lib/src/main/kotlin/at/bitfire/synctools/utils/SequenceReader.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/utils/SequenceReader.kt
@@ -1,0 +1,52 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.utils
+
+import java.io.Reader
+
+/**
+ * A [Reader] that allows loading data from a [Sequence] of [String]s.
+ */
+class SequenceReader(private val linesProvider: () -> Sequence<String>) : Reader() {
+    constructor(lines: Sequence<String>) : this({ lines })
+
+    private var iterator = linesProvider().iterator()
+    private var currentLine: String? = null
+    private var currentPos = 0
+    private var closed = false
+
+    override fun reset() {
+        iterator = linesProvider().iterator()
+        currentLine = null
+        currentPos = 0
+        closed = false
+    }
+
+    override fun read(cbuf: CharArray, off: Int, len: Int): Int {
+        check(!closed) { "Reader closed" }
+        var charsRead = 0
+        while (charsRead < len) {
+            if (currentLine == null || currentPos >= currentLine!!.length) {
+                if (!iterator.hasNext()) {
+                    if (charsRead == 0) return -1
+                    break
+                }
+                currentLine = iterator.next() + "\n"
+                currentPos = 0
+            }
+            val charsToCopy = minOf(len - charsRead, currentLine!!.length - currentPos)
+            currentLine!!.toCharArray(currentPos, currentPos + charsToCopy).copyInto(cbuf, off + charsRead)
+            currentPos += charsToCopy
+            charsRead += charsToCopy
+        }
+        return charsRead
+    }
+
+    override fun close() {
+        closed = true
+    }
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/utils/SequenceReader.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/utils/SequenceReader.kt
@@ -11,20 +11,11 @@ import java.io.Reader
 /**
  * A [Reader] that allows loading data from a [Sequence] of [String]s.
  */
-class SequenceReader(private val linesProvider: () -> Sequence<String>) : Reader() {
-    constructor(lines: Sequence<String>) : this({ lines })
-
-    private var iterator = linesProvider().iterator()
+class SequenceReader(lines: Sequence<String>) : Reader() {
+    private var iterator = lines.iterator()
     private var currentLine: String? = null
     private var currentPos = 0
     private var closed = false
-
-    override fun reset() {
-        iterator = linesProvider().iterator()
-        currentLine = null
-        currentPos = 0
-        closed = false
-    }
 
     override fun read(cbuf: CharArray, off: Int, len: Int): Int {
         check(!closed) { "Reader closed" }


### PR DESCRIPTION
# Context

Right now we are loading the whole iCalendar into memory when applying the preprocessors, which breaks the whole point to use Readers in the first place. This can lead to Out Of Memory exceptions on super large iCalendar documents, or in devices with limited memory.

# Changes

- Added a new test (`ICalPreprocessorInstrumentedTest`) that generates a very large iCalendar file.
  _With `Int.MAX_VALUE` events._
- Changed the way `ICalPreprocessor.preprocessStream` works:
  - Instead of applying the `StreamPreprocessor`s on the whole document at once, they are applied line-wise.
    _Note: to avoid having to apply regex conditions (which can get expensive) hundred of thousands of times, the lines are chunked in groups of 1000 lines (arbitrary, can be adjusted)._
  - If the `Reader` given to the `ICalPreprocessor` support `reset`, the result of this function will be a `SequenceReader`. This is a new class, that converts sequences into a `Reader`. **Note that this function does not support `reset`, by the way sequences work in Kotlin.**
  - If the `Reader` doesn't support `reset`, it will have to be loaded fully into memory anyway.
- Since `StreamPreprocessor` is now simpler (most logic has been moved into `ICalPreprocessor`), they are now interfaces.

> [!NOTE]
> It is possible to run the pre-processors in a line-basis is because they are applied line-wise. If at some point we require a preprocessor that needs to fix multiple lines at once (maybe description fixes? which allow multi-line), we might have to re-do this.