### PR TITLE
Minor refactoring of RecurrenceFieldsHandler

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldsHandler.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldsHandler.kt
@@ -152,9 +152,7 @@ class RecurrenceFieldsHandler(
      * @see at.bitfire.synctools.mapping.calendar.builder.EndTimeBuilder.alignWithDtStart
      */
     fun alignUntil(recur: Recur, startDate: Date): Recur {
-        val until: Date? = recur.until
-        if (until == null)
-            return recur
+        val until: Date = recur.until ?: return recur
 
         if (until is DateTime) {
             // UNTIL is DATE-TIME


### PR DESCRIPTION
Main reason for the PR is to add the all-day RDATE test.

Other changes:

- value-type PERIOD is not defined for EXDATE, check was useless
- `if` changed to `when` for more clarity
- two minor syntax changes (suggested by Android Studio)