### PR TITLE
Fix phone number processing for URI type

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/vcard4android/contactrow/PhoneBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/vcard4android/contactrow/PhoneBuilder.kt
@@ -21,16 +21,21 @@ class PhoneBuilder(dataRowUri: Uri, rawContactId: Long?, contact: Contact, readO
     override fun build(): List<BatchOperation.CpoBuilder> {
         val result = LinkedList<BatchOperation.CpoBuilder>()
         for (phoneNumber in contact.phoneNumbers) {
-            val number = phoneNumber.property
-            if (number.text.isNullOrBlank())
+            val tel = phoneNumber.property
+
+            // TEL can have either a TEXT (default for vCard 3 compatibility) or an URI value.
+            val number = tel.uri?.number ?: tel.text
+
+            // Skip empty numbers
+            if (number.isNullOrBlank())
                 continue
 
-            val types = number.types
+            val types = tel.types
 
             // preferred number?
             var pref: Int? = null
             try {
-                pref = number.pref
+                pref = tel.pref
             } catch(e: IllegalStateException) {
                 logger.log(Level.FINER, "Can't understand phone number PREF", e)
             }
@@ -89,7 +94,7 @@ class PhoneBuilder(dataRowUri: Uri, rawContactId: Long?, contact: Contact, readO
 
             result += newDataRow()
                 .withValue(Phone.MIMETYPE, Phone.CONTENT_ITEM_TYPE)
-                .withValue(Phone.NUMBER, number.text)
+                .withValue(Phone.NUMBER, number)
                 .withValue(Phone.TYPE, typeCode)
                 .withValue(Phone.LABEL, typeLabel)
                 .withValue(Phone.IS_PRIMARY, if (isPrimary) 1 else 0)

--- a/lib/src/test/kotlin/at/bitfire/vcard4android/contactrow/PhoneBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/vcard4android/contactrow/PhoneBuilderTest.kt
@@ -13,6 +13,7 @@ import at.bitfire.vcard4android.LabeledProperty
 import at.bitfire.vcard4android.property.CustomType
 import ezvcard.parameter.TelephoneType
 import ezvcard.property.Telephone
+import ezvcard.util.TelUri
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,9 +40,19 @@ class PhoneBuilderTest {
     }
 
     @Test
-    fun testNumber_Value() {
+    fun testNumber_Value_Text() {
         PhoneBuilder(Uri.EMPTY, null, Contact().apply {
             phoneNumbers += LabeledProperty(Telephone("+1 555 12345"))
+        }, false).build().also { result ->
+            assertEquals(1, result.size)
+            assertEquals("+1 555 12345", result[0].values[CommonDataKinds.Phone.NUMBER])
+        }
+    }
+
+    @Test
+    fun testNumber_Value_Uri() {
+        PhoneBuilder(Uri.EMPTY, null, Contact().apply {
+            phoneNumbers += LabeledProperty(Telephone(TelUri.parse("tel:+1 555 12345")))
         }, false).build().also { result ->
             assertEquals(1, result.size)
             assertEquals("+1 555 12345", result[0].values[CommonDataKinds.Phone.NUMBER])


### PR DESCRIPTION
## Purpose

Fix phone number processing for URI type in vCard4.

## Short description

- Update `PhoneBuilderTest` to include test case for URI type phone numbers
- Modify `PhoneBuilder` to handle both TEXT and URI values for phone numbers:
  - Extract phone number from `tel.uri?.number` if available, otherwise fall back to `tel.text`
  - Use the extracted phone number value when building the data row