### PR TITLE
Refactor DmfsTask, introducing Entity as data object

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskTest.kt
@@ -117,10 +117,10 @@ class DmfsTaskTest(
         assertNotNull("Couldn't add task", uri)
 
         // read and parse event from calendar provider
-        val testTask = taskList!!.getTask(ContentUris.parseId(uri))
+        val testTask = taskList!!.getLegacyTask(ContentUris.parseId(uri))
         try {
             assertNotNull("Inserted task is not here", testTask)
-            val task2 = testTask.task
+            val task2 = testTask?.task
             assertNotNull("Inserted task is empty", task2)
 
             // compare with original event
@@ -134,7 +134,7 @@ class DmfsTaskTest(
             assertEquals(task.relatedTo, task2.relatedTo)
             assertEquals(task.unknownProperties, task2.unknownProperties)
         } finally {
-            testTask.delete()
+            testTask?.delete()
         }
     }
 
@@ -161,7 +161,7 @@ class DmfsTaskTest(
 
         val uri = DmfsTask(taskList!!, task, "9468a4cf-0d5b-4379-a704-12f1f84100ba", null, 0).add()
         val task2 = taskList!!.getTask(ContentUris.parseId(uri))
-        assertEquals(1050, task2.task?.alarms?.size)
+        assertEquals(1050, task2?.task?.alarms?.size)
     }
 
     @Test
@@ -184,20 +184,20 @@ class DmfsTaskTest(
         val testTask = taskList!!.getTask(ContentUris.parseId(uri))
         try {
             // update test event in calendar
-            val task2 = testTask.task!!
+            val task2 = testTask?.task!!
             task2.summary = "Updated event"                     // change value
             task.location = null                                // remove value
             task2.duration = Duration(java.time.Duration.ofMinutes(10))     // add value
             testTask.update(task2)
 
             // read again and verify result
-            val updatedTask = taskList!!.getTask(ContentUris.parseId(uri)).task!!
+            val updatedTask = taskList!!.getTask(ContentUris.parseId(uri))?.task!!
             assertEquals(task2.summary, updatedTask.summary)
             assertEquals(task2.location, updatedTask.location)
             assertEquals(task2.dtStart, updatedTask.dtStart)
             assertEquals(task2.duration!!.value, updatedTask.duration!!.value)
         } finally {
-            testTask.delete()
+            testTask?.delete()
         }
     }
 

--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
@@ -832,7 +832,7 @@ class DmfsTaskBuilderTest (
         val testTask = taskList!!.getTask(ContentUris.parseId(uri))
         try {
             // read again and verify result
-            val task2 = testTask.task!!
+            val task2 = testTask?.task!!
             assertEquals(task.summary, task2.summary)
             assertEquals(task.description, task2.description)
             assertEquals(task.location, task2.location)
@@ -840,7 +840,7 @@ class DmfsTaskBuilderTest (
             assertEquals(task.due!!.date, task2.due!!.date)
             Assert.assertTrue(task2.isAllDay())
         } finally {
-            testTask.delete()
+            testTask?.delete()
         }
     }
 

--- a/lib/src/main/kotlin/at/bitfire/ical4android/DmfsTask.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/DmfsTask.kt
@@ -8,6 +8,7 @@ package at.bitfire.ical4android
 
 import android.content.ContentUris
 import android.content.ContentValues
+import android.content.Entity
 import android.net.Uri
 import android.os.RemoteException
 import at.bitfire.synctools.mapping.tasks.DmfsTaskBuilder
@@ -20,6 +21,7 @@ import at.bitfire.synctools.storage.toContentValues
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.parameter.RelType
 import net.fortuna.ical4j.model.property.RelatedTo
+import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.Properties
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import java.io.FileNotFoundException
@@ -27,40 +29,36 @@ import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
- * Stores and retrieves VTODO iCalendar objects (represented as [Task]s) to/from the
- * tasks.org-content provider (currently tasks.org and OpenTasks).
+ * Stores and retrieves tasks to/from the tasks.org-content provider (currently tasks.org and
+ * OpenTasks).
  *
- * Extend this class to process specific fields of the task.
+ * A task in the context of this class is one row in the [TaskContract.Tasks] table,
+ * plus associated data rows (like alarms and reminders).
+ *
+ * Exceptions (of recurring tasks) have their own entries in the [TaskContract.Tasks] table and thus
+ * are separate.
  *
  * The SEQUENCE field is stored in [Tasks.SYNC_VERSION], so don't use [Tasks.SYNC_VERSION]
  * for anything else.
+ *
+ * @param taskList  task list where the task is stored
+ * @param values    entity with all columns, as returned by the calendar provider; [TaskContract.Tasks._ID] must be set to a non-null value
  */
+
 class DmfsTask(
-    val taskList: DmfsTaskList
+    val taskList: DmfsTaskList,
+    val values: Entity
 ) {
 
     private val logger = Logger.getLogger(javaClass.name)
 
-    var id: Long? = null
-    var syncId: String? = null
-    var eTag: String? = null
-    var flags: Int = 0
+    private val mainValues
+        get() = values.entityValues
 
-
-    constructor(taskList: DmfsTaskList, values: ContentValues): this(taskList) {
-        id = values.getAsLong(Tasks._ID)
-        syncId = values.getAsString(Tasks._SYNC_ID)
-        eTag = values.getAsString(COLUMN_ETAG)
-        flags = values.getAsInteger(COLUMN_FLAGS) ?: 0
-    }
-
-    constructor(taskList: DmfsTaskList, task: Task, syncId: String?, eTag: String?, flags: Int): this(taskList) {
-        this.task = task
-        this.syncId = syncId
-        this.eTag = eTag
-        this.flags = flags
-    }
-
+    var id: Long = mainValues.getAsLong(Tasks._ID)
+    var syncId: String? = mainValues.getAsString(Tasks._SYNC_ID)
+    var eTag: String? = mainValues.getAsString(COLUMN_ETAG)
+    var flags: Int = mainValues.getAsInteger(COLUMN_FLAGS) ?: 0
 
     var task: Task? = null
         /**

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilder.kt
@@ -6,14 +6,14 @@
 
 package at.bitfire.synctools.mapping.tasks
 
-import at.bitfire.ical4android.DmfsTask.Companion.COLUMN_ETAG
-import at.bitfire.ical4android.DmfsTask.Companion.COLUMN_FLAGS
-import at.bitfire.ical4android.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
 import at.bitfire.ical4android.ICalendar
 import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.UnknownProperty
 import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
 import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
+import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.COLUMN_ETAG
+import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.COLUMN_FLAGS
+import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.storage.tasks.TasksBatchOperation
 import at.bitfire.synctools.util.AndroidTimeUtils

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskProcessor.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskProcessor.kt
@@ -7,11 +7,11 @@
 package at.bitfire.synctools.mapping.tasks
 
 import android.content.ContentValues
-import at.bitfire.ical4android.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
 import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.UnknownProperty
 import at.bitfire.ical4android.util.TimeApiExtensions.toLocalDate
 import at.bitfire.synctools.icalendar.propertyListOf
+import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.util.AndroidTimeUtils
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
@@ -4,72 +4,64 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-package at.bitfire.ical4android
+package at.bitfire.synctools.storage.tasks
 
 import android.content.ContentUris
 import android.content.ContentValues
+import android.content.Entity
 import android.net.Uri
-import android.os.RemoteException
+import at.bitfire.ical4android.Task
 import at.bitfire.synctools.mapping.tasks.DmfsTaskBuilder
 import at.bitfire.synctools.mapping.tasks.DmfsTaskProcessor
-import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
+import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.storage.LocalStorageException
-import at.bitfire.synctools.storage.tasks.DmfsTaskList
-import at.bitfire.synctools.storage.tasks.TasksBatchOperation
 import at.bitfire.synctools.storage.toContentValues
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.parameter.RelType
 import net.fortuna.ical4j.model.property.RelatedTo
-import org.dmfs.tasks.contract.TaskContract.Properties
-import org.dmfs.tasks.contract.TaskContract.Tasks
+import org.dmfs.tasks.contract.TaskContract
 import java.io.FileNotFoundException
 import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
- * Stores and retrieves VTODO iCalendar objects (represented as [Task]s) to/from the
- * tasks.org-content provider (currently tasks.org and OpenTasks).
+ * Stores and retrieves tasks to/from the tasks.org-content provider (currently tasks.org and
+ * OpenTasks).
  *
- * Extend this class to process specific fields of the task.
+ * A task in the context of this class is one row in the [org.dmfs.tasks.contract.TaskContract.Tasks] table,
+ * plus associated data rows (like alarms and reminders).
  *
- * The SEQUENCE field is stored in [Tasks.SYNC_VERSION], so don't use [Tasks.SYNC_VERSION]
+ * Exceptions (of recurring tasks) have their own entries in the [org.dmfs.tasks.contract.TaskContract.Tasks] table and thus
+ * are separate.
+ *
+ * The SEQUENCE field is stored in [org.dmfs.tasks.contract.TaskContract.CommonSyncColumns.SYNC_VERSION], so don't use [org.dmfs.tasks.contract.TaskContract.CommonSyncColumns.SYNC_VERSION]
  * for anything else.
+ *
+ * @param taskList  task list where the task is stored
+ * @param values    entity with all columns, as returned by the calendar provider; [org.dmfs.tasks.contract.TaskContract.Tasks._ID] must be set to a non-null value
  */
-@Deprecated("Use storage.tasks.DmfsTask instead")
 class DmfsTask(
-    val taskList: DmfsTaskList
+    val taskList: DmfsTaskList,
+    val values: Entity
 ) {
 
     private val logger = Logger.getLogger(javaClass.name)
 
-    var id: Long? = null
-    var syncId: String? = null
-    var eTag: String? = null
-    var flags: Int = 0
+    private val mainValues
+        get() = values.entityValues
 
-
-    constructor(taskList: DmfsTaskList, values: ContentValues): this(taskList) {
-        id = values.getAsLong(Tasks._ID)
-        syncId = values.getAsString(Tasks._SYNC_ID)
-        eTag = values.getAsString(COLUMN_ETAG)
-        flags = values.getAsInteger(COLUMN_FLAGS) ?: 0
-    }
-
-    constructor(taskList: DmfsTaskList, task: Task, syncId: String?, eTag: String?, flags: Int): this(taskList) {
-        this.task = task
-        this.syncId = syncId
-        this.eTag = eTag
-        this.flags = flags
-    }
-
+    var id: Long = mainValues.getAsLong(TaskContract.Tasks._ID)
+    var syncId: String? = mainValues.getAsString(TaskContract.Tasks._SYNC_ID)
+    var eTag: String? = mainValues.getAsString(COLUMN_ETAG)
+    var flags: Int = mainValues.getAsInteger(COLUMN_FLAGS) ?: 0
 
     var task: Task? = null
         /**
          * This getter returns the full task data, either from [task] or, if [task] is null, by reading task
          * number [id] from the task provider
          * @throws IllegalArgumentException if task has not been saved yet
-         * @throws FileNotFoundException if there's no task with [id] in the task provider
-         * @throws RemoteException on task provider errors
+         * @throws java.io.FileNotFoundException if there's no task with [id] in the task provider
+         * @throws android.os.RemoteException on task provider errors
          */
         get() {
             if (field != null)
@@ -89,7 +81,7 @@ class DmfsTask(
                         val processor = DmfsTaskProcessor(taskList)
                         processor.populateTask(values, newTask)
 
-                        if (values.containsKey(Properties.PROPERTY_ID)) {
+                        if (values.containsKey(TaskContract.Properties.PROPERTY_ID)) {
                             // process the first property, which is combined with the task row
                             processor.populateProperty(values, newTask)
 
@@ -101,7 +93,7 @@ class DmfsTask(
 
                         // Special case: parent_id set, but no matching parent Relation row (like given by aCalendar+)
                         val relatedToList = newTask.relatedTo
-                        values.getAsLong(Tasks.PARENT_ID)?.let { parentId ->
+                        values.getAsLong(TaskContract.Tasks.PARENT_ID)?.let { parentId ->
                             val hasParentRelation = relatedToList.any { relatedTo ->
                                 val relatedType = relatedTo.getParameter<RelType>(Parameter.RELTYPE)
                                 relatedType == RelType.PARENT || relatedType == null /* RelType.PARENT is the default value */
@@ -109,7 +101,7 @@ class DmfsTask(
                             if (!hasParentRelation) {
                                 // get UID of parent task
                                 val parentContentUri = ContentUris.withAppendedId(taskList.tasksUri(), parentId)
-                                client.query(parentContentUri, arrayOf(Tasks._UID), null, null, null)?.use { cursor ->
+                                client.query(parentContentUri, arrayOf(TaskContract.Tasks._UID), null, null, null)?.use { cursor ->
                                     if (cursor.moveToNext()) {
                                         // add RelatedTo for parent task
                                         relatedToList += RelatedTo(cursor.getString(0))
@@ -137,8 +129,8 @@ class DmfsTask(
      *
      * @return content URI of the created task
      *
-     * @throws LocalStorageException when the tasks provider doesn't return a result row
-     * @throws RemoteException on tasks provider errors
+     * @throws at.bitfire.synctools.storage.LocalStorageException when the tasks provider doesn't return a result row
+     * @throws android.os.RemoteException on tasks provider errors
      */
     fun add(): Uri {
         val batch = TasksBatchOperation(taskList.provider.client)
@@ -163,7 +155,7 @@ class DmfsTask(
      * @return content URI of the updated task
      *
      * @throws LocalStorageException when the tasks provider doesn't return a result row
-     * @throws RemoteException on tasks provider errors
+     * @throws android.os.RemoteException on tasks provider errors
      */
     fun update(task: Task): Uri {
         this.task = task
@@ -172,9 +164,9 @@ class DmfsTask(
         val batch = TasksBatchOperation(taskList.provider.client)
 
         // remove associated rows which are added later again
-        batch += CpoBuilder
+        batch += BatchOperation.CpoBuilder
             .newDelete(taskList.tasksPropertiesUri())
-            .withSelection("${Properties.TASK_ID}=?", arrayOf(existingId.toString()))
+            .withSelection("${TaskContract.Properties.TASK_ID}=?", arrayOf(existingId.toString()))
 
         // update task
         val builder = DmfsTaskBuilder(taskList, task, id, syncId, eTag, flags)
@@ -184,7 +176,7 @@ class DmfsTask(
         builder.insertProperties(batch, null)
 
         batch.commit()
-        return ContentUris.withAppendedId(Tasks.getContentUri(taskList.providerName.authority), existingId)
+        return ContentUris.withAppendedId(TaskContract.Tasks.getContentUri(taskList.providerName.authority), existingId)
     }
 
     fun update(values: ContentValues) {
@@ -196,7 +188,7 @@ class DmfsTask(
      *
      * @return number of affected rows
      *
-     * @throws RemoteException on tasks provider errors
+     * @throws android.os.RemoteException on tasks provider errors
      */
     fun delete(): Int {
         return taskList.provider.client.delete(taskSyncURI(), null, null)
@@ -208,11 +200,11 @@ class DmfsTask(
     }
 
     companion object {
-        const val UNKNOWN_PROPERTY_DATA = Properties.DATA0
+        const val UNKNOWN_PROPERTY_DATA = TaskContract.Properties.DATA0
 
-        const val COLUMN_ETAG = Tasks.SYNC1
+        const val COLUMN_ETAG = TaskContract.Tasks.SYNC1
 
-        const val COLUMN_FLAGS = Tasks.SYNC2
+        const val COLUMN_FLAGS = TaskContract.Tasks.SYNC2
     }
 
 }

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
@@ -38,19 +38,40 @@ import java.util.logging.Logger
  * for anything else.
  *
  * @param taskList  task list where the task is stored
- * @param values    entity with all columns, as returned by the calendar provider; [org.dmfs.tasks.contract.TaskContract.Tasks._ID] must be set to a non-null value
+ * @param values    entity with all columns, as returned by the task provider; [org.dmfs.tasks.contract.TaskContract.Tasks._ID]
+ *                  must be set to a non-null value for existing tasks, and may be absent for new (unsaved) tasks
  */
 class DmfsTask(
     val taskList: DmfsTaskList,
     val values: Entity
 ) {
 
+    /**
+     * Secondary constructor for creating a new (not yet saved) task.
+     *
+     * @param taskList  task list where the task will be stored
+     * @param task      task data
+     * @param syncId    remote file name (e.g. `mytask.ics`)
+     * @param eTag      remote ETag
+     * @param flags     local flags (e.g. [at.bitfire.davdroid.resource.LocalResource.FLAG_REMOTELY_PRESENT])
+     */
+    constructor(taskList: DmfsTaskList, task: Task, syncId: String?, eTag: String?, flags: Int) : this(
+        taskList = taskList,
+        values = Entity(ContentValues().apply {
+            if (syncId != null) put(TaskContract.Tasks._SYNC_ID, syncId)
+            put(COLUMN_ETAG, eTag)
+            put(COLUMN_FLAGS, flags)
+        })
+    ) {
+        this.task = task
+    }
+
     private val logger = Logger.getLogger(javaClass.name)
 
     private val mainValues
         get() = values.entityValues
 
-    var id: Long = mainValues.getAsLong(TaskContract.Tasks._ID)
+    var id: Long? = mainValues.getAsLong(TaskContract.Tasks._ID)
     var syncId: String? = mainValues.getAsString(TaskContract.Tasks._SYNC_ID)
     var eTag: String? = mainValues.getAsString(COLUMN_ETAG)
     var flags: Int = mainValues.getAsInteger(COLUMN_FLAGS) ?: 0

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
@@ -31,11 +31,8 @@ import java.util.logging.Logger
  * A task in the context of this class is one row in the [org.dmfs.tasks.contract.TaskContract.Tasks] table,
  * plus associated data rows (like alarms and reminders).
  *
- * Exceptions (of recurring tasks) have their own entries in the [org.dmfs.tasks.contract.TaskContract.Tasks] table and thus
- * are separate.
- *
- * The SEQUENCE field is stored in [org.dmfs.tasks.contract.TaskContract.CommonSyncColumns.SYNC_VERSION], so don't use [org.dmfs.tasks.contract.TaskContract.CommonSyncColumns.SYNC_VERSION]
- * for anything else.
+ * The SEQUENCE field is stored in [org.dmfs.tasks.contract.TaskContract.CommonSyncColumns.SYNC_VERSION], so
+ * don't use it for anything else.
  *
  * @param taskList  task list where the task is stored
  * @param values    entity with all columns, as returned by the task provider; [org.dmfs.tasks.contract.TaskContract.Tasks._ID]

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -11,7 +11,6 @@ import android.content.ContentValues
 import android.content.Entity
 import android.net.Uri
 import android.os.RemoteException
-import at.bitfire.ical4android.DmfsTask
 import at.bitfire.ical4android.TaskProvider
 import at.bitfire.ical4android.util.MiscUtils.asSyncAdapter
 import at.bitfire.synctools.storage.BatchOperation
@@ -20,6 +19,7 @@ import at.bitfire.synctools.storage.toContentValues
 import org.dmfs.tasks.contract.TaskContract
 import java.util.LinkedList
 import java.util.logging.Logger
+import at.bitfire.ical4android.DmfsTask as LegacyDmfsTask
 
 /**
  * Represents a locally stored task list, containing [DmfsTask]s (tasks).
@@ -139,6 +139,17 @@ class DmfsTaskList(
             throw LocalStorageException("Couldn't query task entity", e)
         }
         return null
+    }
+
+    /**
+     * Gets a specific task, identified by its ID, from this task list.
+     *
+     * @param id    task ID
+     * @return task (or `null` if not found)
+     */
+    fun getLegacyTask(id: Long): LegacyDmfsTask? {
+        val entity = getTaskEntity(id, null) ?: return null
+        return LegacyDmfsTask(this, entity.entityValues)
     }
 
     /**

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -8,6 +8,7 @@ package at.bitfire.synctools.storage.tasks
 
 import android.content.ContentUris
 import android.content.ContentValues
+import android.content.Entity
 import android.net.Uri
 import android.os.RemoteException
 import at.bitfire.ical4android.DmfsTask
@@ -21,7 +22,7 @@ import java.util.LinkedList
 import java.util.logging.Logger
 
 /**
- * Represents a locally stored task list, containing [at.bitfire.ical4android.DmfsTask]s (tasks).
+ * Represents a locally stored task list, containing [DmfsTask]s (tasks).
  * Communicates with tasks.org-compatible content providers (currently tasks.org and OpenTasks) to store the tasks.
  */
 class DmfsTaskList(
@@ -81,15 +82,19 @@ class DmfsTaskList(
      * @param where selection
      * @param whereArgs arguments for selection
      *
-     * @return events from this task list which match the selection
+     * @return tasks from this task list which match the selection
      */
     fun findTasks(where: String? = null, whereArgs: Array<String>? = null): List<DmfsTask> {
         val tasks = LinkedList<DmfsTask>()
         try {
             val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
-            client.query(tasksUri(), null, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
-                while (cursor.moveToNext())
-                    tasks += DmfsTask(this, cursor.toContentValues())
+            client.query(tasksUri(), arrayOf(TaskContract.Tasks._ID), protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+                while (cursor.moveToNext()) {
+                    val taskId = cursor.getLong(0)
+                    val entity = getTaskEntity(taskId)
+                    if (entity != null)
+                        tasks += DmfsTask(this, entity)
+                }
             }
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't query ${providerName.authority} tasks", e)
@@ -97,9 +102,45 @@ class DmfsTaskList(
         return tasks
     }
 
-    fun getTask(id: Long) = findTasks("${TaskContract.Tasks._ID}=?", arrayOf(id.toString())).firstOrNull()
-        ?: throw LocalStorageException("Couldn't query ${providerName.authority} tasks")
-    
+    /**
+     * Gets a task from this task list by given id.
+     *
+     * @return task from this task list which matches the selection
+     */
+    fun getTask(id: Long): DmfsTask? {
+        val values = getTaskEntity(id) ?: return null
+        return DmfsTask(this, values)
+    }
+
+    /**
+     * Retrieves a task as entity from this task list by given id and selection.
+     *
+     * @param where selection
+     * @param whereArgs arguments for selection
+     *
+     * @return task from this task list which matches the selection
+     */
+    fun getTaskEntity(id: Long, where: String? = null, whereArgs: Array<String>? = null): Entity? {
+        try {
+            client.query(taskUri(id, true), null, where, whereArgs, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    // first row holds entity main values
+                    val entity = Entity(cursor.toContentValues())
+                    // remaining rows hold entity subvalues (extended properties)
+                    while (cursor.moveToNext()) {
+                        val cv = cursor.toContentValues()
+                        val mimetype = cv.getAsString(TaskContract.PropertyColumns.MIMETYPE) // CONTENT_ITEM_TYPE of extended property
+                        entity.addSubValue(tasksPropertyUri(mimetype), cv)
+                    }
+                    return entity
+                }
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query task entity", e)
+        }
+        return null
+    }
+
     /**
      * Updates tasks in this task list.
      *
@@ -176,6 +217,9 @@ class DmfsTaskList(
 
     fun tasksPropertiesUri() =
         TaskContract.Properties.getContentUri(providerName.authority).asSyncAdapter(account)
+
+    fun tasksPropertyUri(mimetype: String): Uri =
+        tasksPropertiesUri().buildUpon().appendPath(mimetype).build()!!
 
     /**
      * Restricts a given selection/where clause to this task list ID.


### PR DESCRIPTION
Refactors DmfsTask by introducing Entity as the data object and updating related code accordingly. 

Matching davx5-ose core PR: bitfireAT/davx5-ose/pull/2192