### PR TITLE
Ignore tests failing due to incomplete ical4j 4.x migration

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistryTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistryTest.kt
@@ -14,10 +14,12 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assume
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import java.time.ZoneId
 import java.time.zone.ZoneRulesException
 
+@Ignore("ical4j 4.x")
 class AndroidCompatTimeZoneRegistryTest {
 
     lateinit var ical4jRegistry: TimeZoneRegistry

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidTimeZonesTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidTimeZonesTest.kt
@@ -9,11 +9,13 @@ package at.bitfire.ical4android
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import org.junit.Assert
 import org.junit.Assert.assertNotNull
+import org.junit.Ignore
 import org.junit.Test
 import java.time.ZoneId
 import java.time.format.TextStyle
 import java.util.Locale
 
+@Ignore("ical4j 4.x")
 class AndroidTimeZonesTest {
 
     @Test

--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
@@ -46,9 +46,11 @@ import org.junit.After
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import java.time.ZoneId
 
+@Ignore("ical4j 4.x")
 class DmfsTaskBuilderTest (
     providerName: TaskProvider.ProviderName
 ): DmfsStyleProvidersTaskTest(providerName) {

--- a/lib/src/test/kotlin/at/bitfire/ical4android/ICalendarTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/ical4android/ICalendarTest.kt
@@ -23,12 +23,14 @@ import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import java.io.StringReader
 import java.time.Duration
 import java.time.Period
 import java.util.Date
 
+@Ignore("ical4j 4.x")
 class ICalendarTest {
 
 	// UTC timezone

--- a/lib/src/test/kotlin/at/bitfire/ical4android/Ical4jServiceLoaderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/ical4android/Ical4jServiceLoaderTest.kt
@@ -10,9 +10,11 @@ import net.fortuna.ical4j.data.CalendarBuilder
 import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.component.VEvent
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import java.io.StringReader
 
+@Ignore("ical4j 4.x")
 class Ical4jServiceLoaderTest {
 
     @Test

--- a/lib/src/test/kotlin/at/bitfire/ical4android/TaskReaderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/ical4android/TaskReaderTest.kt
@@ -27,6 +27,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import java.io.InputStreamReader
 import java.io.StringReader
@@ -34,6 +35,7 @@ import java.io.StringWriter
 import java.nio.charset.Charset
 import java.time.Duration
 
+@Ignore("ical4j 4.x")
 class TaskReaderTest {
 
     val testProdId = ProdId(javaClass.name)

--- a/lib/src/test/kotlin/at/bitfire/ical4android/TaskTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/ical4android/TaskTest.kt
@@ -12,8 +12,10 @@ import net.fortuna.ical4j.model.property.DtStart
 import net.fortuna.ical4j.model.property.Due
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 
+@Ignore("ical4j 4.x")
 class TaskTest {
 
     @Test

--- a/lib/src/test/kotlin/at/bitfire/ical4android/TaskWriterTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/ical4android/TaskWriterTest.kt
@@ -13,10 +13,12 @@ import net.fortuna.ical4j.model.property.Action
 import net.fortuna.ical4j.model.property.DtStart
 import net.fortuna.ical4j.model.property.ProdId
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import java.io.StringWriter
 import java.time.Duration
 
+@Ignore("ical4j 4.x")
 class TaskWriterTest {
 
     val testProdId = ProdId(javaClass.name)

--- a/lib/src/test/kotlin/at/bitfire/ical4android/UnknownPropertyTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/ical4android/UnknownPropertyTest.kt
@@ -15,10 +15,12 @@ import net.fortuna.ical4j.model.property.Uid
 import org.json.JSONException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class UnknownPropertyTest {
 

--- a/lib/src/test/kotlin/at/bitfire/ical4android/util/DateUtilsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/ical4android/util/DateUtilsTest.kt
@@ -14,10 +14,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import java.time.ZoneId
 import java.util.TimeZone
 
+@Ignore("ical4j 4.x")
 class DateUtilsTest {
 
     @Test

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/AssociatedComponentsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/AssociatedComponentsTest.kt
@@ -10,8 +10,10 @@ import net.fortuna.ical4j.model.Date
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.RecurrenceId
 import net.fortuna.ical4j.model.property.Uid
+import org.junit.Ignore
 import org.junit.Test
 
+@Ignore("ical4j 4.x")
 class AssociatedComponentsTest {
 
     @Test(expected = IllegalArgumentException::class)

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitterTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitterTest.kt
@@ -16,8 +16,10 @@ import net.fortuna.ical4j.model.property.Sequence
 import net.fortuna.ical4j.model.property.Uid
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 
+@Ignore("ical4j 4.x")
 class CalendarUidSplitterTest {
 
     @Test

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarGeneratorTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarGeneratorTest.kt
@@ -19,10 +19,12 @@ import net.fortuna.ical4j.model.property.RecurrenceId
 import net.fortuna.ical4j.model.property.Uid
 import net.fortuna.ical4j.util.TimeZones
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import java.io.StringWriter
 import java.time.Duration
 
+@Ignore("ical4j 4.x")
 class ICalendarGeneratorTest {
 
     private val tzRegistry = TimeZoneRegistryFactory.getInstance().createRegistry()

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarParserTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarParserTest.kt
@@ -15,11 +15,13 @@ import io.mockk.junit4.MockKRule
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.io.Reader
 import java.io.StringReader
 
+@Ignore("ical4j 4.x")
 class ICalendarParserTest {
 
     @get:Rule

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/Ical4jTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/Ical4jTest.kt
@@ -28,11 +28,13 @@ import net.fortuna.ical4j.model.property.ProdId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Ignore
 import org.junit.Test
 import java.io.StringReader
 import java.io.StringWriter
 import java.time.Period
 
+@Ignore("ical4j 4.x")
 class Ical4jTest {
 
     private val tzReg = TimeZoneRegistryFactory.getInstance().createRegistry()

--- a/lib/src/test/kotlin/at/bitfire/synctools/icalendar/validation/ICalPreprocessorTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/icalendar/validation/ICalPreprocessorTest.kt
@@ -16,6 +16,7 @@ import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.component.VEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.io.InputStreamReader
@@ -24,6 +25,7 @@ import java.io.StringReader
 import java.io.Writer
 import java.util.UUID
 
+@Ignore("ical4j 4.x")
 class ICalPreprocessorTest {
 
     @get:Rule

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/AndroidEventHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/AndroidEventHandlerTest.kt
@@ -25,10 +25,12 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class AndroidEventHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/AttendeeMappingsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/AttendeeMappingsTest.kt
@@ -13,10 +13,12 @@ import net.fortuna.ical4j.model.parameter.Role
 import net.fortuna.ical4j.model.property.Attendee
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class AttendeeMappingsTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AccessLevelBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AccessLevelBuilderTest.kt
@@ -17,10 +17,12 @@ import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Clazz
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class AccessLevelBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AllDayBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AllDayBuilderTest.kt
@@ -16,10 +16,12 @@ import net.fortuna.ical4j.model.Date
 import net.fortuna.ical4j.model.DateTime
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.DtStart
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class AllDayBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AttendeesBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AttendeesBuilderTest.kt
@@ -24,11 +24,13 @@ import net.fortuna.ical4j.model.property.Attendee
 import net.fortuna.ical4j.model.property.Organizer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.net.URI
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class AttendeesBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AvailabilityBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AvailabilityBuilderTest.kt
@@ -14,10 +14,12 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Transp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class AvailabilityBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/CategoriesBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/CategoriesBuilderTest.kt
@@ -17,10 +17,12 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Categories
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class CategoriesBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/ColorBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/ColorBuilderTest.kt
@@ -19,11 +19,13 @@ import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Color
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class ColorBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/DescriptionBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/DescriptionBuilderTest.kt
@@ -15,10 +15,12 @@ import net.fortuna.ical4j.model.property.Description
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class DescriptionBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/DurationBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/DurationBuilderTest.kt
@@ -21,11 +21,13 @@ import net.fortuna.ical4j.model.property.RRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.time.Period
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class DurationBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/EndTimeBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/EndTimeBuilderTest.kt
@@ -21,12 +21,14 @@ import net.fortuna.ical4j.model.property.RRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.time.Period
 import java.time.ZoneId
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class EndTimeBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/LocationBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/LocationBuilderTest.kt
@@ -15,10 +15,12 @@ import net.fortuna.ical4j.model.property.Location
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class LocationBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/OrganizerBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/OrganizerBuilderTest.kt
@@ -16,10 +16,12 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.parameter.Email
 import net.fortuna.ical4j.model.property.Attendee
 import net.fortuna.ical4j.model.property.Organizer
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class OrganizerBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/OriginalInstanceTimeBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/OriginalInstanceTimeBuilderTest.kt
@@ -18,10 +18,12 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.DtStart
 import net.fortuna.ical4j.model.property.RRule
 import net.fortuna.ical4j.model.property.RecurrenceId
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class OriginalInstanceTimeBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/RecurrenceFieldsBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/RecurrenceFieldsBuilderTest.kt
@@ -22,10 +22,12 @@ import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.ExRule
 import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class RecurrenceFieldsBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/RemindersBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/RemindersBuilderTest.kt
@@ -22,11 +22,13 @@ import net.fortuna.ical4j.model.property.Action
 import net.fortuna.ical4j.model.property.DtEnd
 import net.fortuna.ical4j.model.property.DtStart
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.time.Period
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class RemindersBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/SequenceBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/SequenceBuilderTest.kt
@@ -14,10 +14,12 @@ import at.bitfire.synctools.storage.calendar.EventsContract
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Sequence
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class SequenceBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/StartTimeBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/StartTimeBuilderTest.kt
@@ -17,11 +17,13 @@ import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.DtStart
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.time.ZoneId
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class StartTimeBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/StatusBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/StatusBuilderTest.kt
@@ -15,10 +15,12 @@ import net.fortuna.ical4j.model.property.Status
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class StatusBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/TitleBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/TitleBuilderTest.kt
@@ -15,10 +15,12 @@ import net.fortuna.ical4j.model.property.Summary
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class TitleBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UidBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UidBuilderTest.kt
@@ -14,10 +14,12 @@ import at.bitfire.synctools.icalendar.propertyListOf
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Uid
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class UidBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UnknownPropertiesBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UnknownPropertiesBuilderTest.kt
@@ -20,10 +20,12 @@ import net.fortuna.ical4j.model.property.Uid
 import net.fortuna.ical4j.model.property.XProperty
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class UnknownPropertiesBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UrlBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UrlBuilderTest.kt
@@ -17,11 +17,13 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Url
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.net.URI
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class UrlBuilderTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AccessLevelHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AccessLevelHandlerTest.kt
@@ -16,10 +16,12 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Clazz
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class AccessLevelHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidTimeFieldTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidTimeFieldTest.kt
@@ -16,9 +16,11 @@ import net.fortuna.ical4j.util.TimeZones
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assume
+import org.junit.Ignore
 import org.junit.Test
 import java.time.ZoneId
 
+@Ignore("ical4j 4.x")
 class AndroidTimeFieldTest {
 
     private val tzRegistry = TimeZoneRegistryFactory.getInstance().createRegistry()

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AttendeesHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AttendeesHandlerTest.kt
@@ -22,11 +22,13 @@ import net.fortuna.ical4j.model.property.Attendee
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.net.URI
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class AttendeesHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AvailabilityHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AvailabilityHandlerTest.kt
@@ -15,10 +15,12 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Transp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class AvailabilityHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/CategoriesHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/CategoriesHandlerTest.kt
@@ -16,10 +16,12 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Categories
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class CategoriesHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/ColorHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/ColorHandlerTest.kt
@@ -15,10 +15,12 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Color
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class ColorHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/DescriptionHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/DescriptionHandlerTest.kt
@@ -13,10 +13,12 @@ import androidx.core.content.contentValuesOf
 import net.fortuna.ical4j.model.component.VEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class DescriptionHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/DurationHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/DurationHandlerTest.kt
@@ -16,10 +16,12 @@ import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.DtEnd
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class DurationHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/EndTimeHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/EndTimeHandlerTest.kt
@@ -18,6 +18,7 @@ import net.fortuna.ical4j.model.property.DtEnd
 import net.fortuna.ical4j.util.TimeZones
 import org.junit.Assert.assertNull
 import org.junit.Assume
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -25,6 +26,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class EndTimeHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/LocationHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/LocationHandlerTest.kt
@@ -13,10 +13,12 @@ import androidx.core.content.contentValuesOf
 import net.fortuna.ical4j.model.component.VEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class LocationHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OrganizerHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OrganizerHandlerTest.kt
@@ -14,10 +14,12 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Organizer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class OrganizerHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OriginalInstanceTimeHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OriginalInstanceTimeHandlerTest.kt
@@ -16,10 +16,12 @@ import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.RecurrenceId
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class OriginalInstanceTimeHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldHandlerTest.kt
@@ -27,10 +27,12 @@ import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class RecurrenceFieldHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RemindersHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RemindersHandlerTest.kt
@@ -15,11 +15,13 @@ import net.fortuna.ical4j.model.property.Action
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assume.assumeTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.time.Duration
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class RemindersHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandlerTest.kt
@@ -13,10 +13,12 @@ import at.bitfire.synctools.storage.calendar.EventsContract
 import net.fortuna.ical4j.model.component.VEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class SequenceHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/StartTimeHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/StartTimeHandlerTest.kt
@@ -18,10 +18,12 @@ import net.fortuna.ical4j.model.DateTime
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.DtStart
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class StartTimeHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/StatusHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/StatusHandlerTest.kt
@@ -14,10 +14,12 @@ import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.Status
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class StatusHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/TitleHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/TitleHandlerTest.kt
@@ -13,10 +13,12 @@ import androidx.core.content.contentValuesOf
 import net.fortuna.ical4j.model.component.VEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class TitleHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UidHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UidHandlerTest.kt
@@ -13,10 +13,12 @@ import androidx.core.content.contentValuesOf
 import net.fortuna.ical4j.model.component.VEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class UidHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UnknownPropertiesHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UnknownPropertiesHandlerTest.kt
@@ -16,10 +16,12 @@ import net.fortuna.ical4j.model.parameter.XParameter
 import net.fortuna.ical4j.model.property.XProperty
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class UnknownPropertiesHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UrlHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UrlHandlerTest.kt
@@ -14,11 +14,13 @@ import at.bitfire.synctools.storage.calendar.EventsContract
 import net.fortuna.ical4j.model.component.VEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.net.URI
 
+@Ignore("ical4j 4.x")
 @RunWith(RobolectricTestRunner::class)
 class UrlHandlerTest {
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
@@ -28,10 +28,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import java.io.StringReader
 import java.time.Duration
 
+@Ignore("ical4j 4.x")
 class AndroidTimeUtilsTest {
 
     val tzRegistry = TimeZoneRegistryFactory.getInstance().createRegistry()!!


### PR DESCRIPTION
Disables all tests that fail due to the currently incomplete ical4j 3 to 4 migration. This way all GitHub checks on pull requests for the `ical4j-3to4` branch should succeed.

I updated #193 to make sure there's no `@Ignore("ical4j 4.x")` annotations left after the migration is done.

Closes #205