### PR TITLE
[ical4j 4.x] Clean up `AndroidTimeUtilsTest`

### DIFF
--- a/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
@@ -21,7 +21,9 @@ import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.parameter.TzId
 import net.fortuna.ical4j.model.parameter.Value
+import net.fortuna.ical4j.model.property.DateListProperty
 import net.fortuna.ical4j.model.property.ExDate
+import net.fortuna.ical4j.model.property.RDate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.fail
@@ -29,6 +31,7 @@ import org.junit.Rule
 import org.junit.Test
 import java.io.StringReader
 import java.time.DateTimeException
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -51,197 +54,10 @@ class AndroidTimeUtilsTest {
     val tzBerlin: TimeZone = tzRegistry.getTimeZone("Europe/Berlin")!!
     val tzToronto: TimeZone = tzRegistry.getTimeZone("America/Toronto")!!
 
-    val tzCustom: TimeZone by lazy {
-        val builder = CalendarBuilder(tzRegistry)
-        val cal = builder.build(
-            StringReader(
-                "BEGIN:VCALENDAR\n" +
-                        "BEGIN:VTIMEZONE\n" +
-                        "TZID:CustomTime\n" +
-                        "BEGIN:STANDARD\n" +
-                        "TZOFFSETFROM:+0310\n" +
-                        "TZOFFSETTO:+0310\n" +
-                        "DTSTART:19600101T000000\n" +
-                        "END:STANDARD\n" +
-                        "END:VTIMEZONE\n" +
-                        "END:VCALENDAR"
-            )
-        )
-        TODO("ical4j 4.x")
-        //TimeZone(cal.getComponent(VTimeZone.VTIMEZONE) as VTimeZone)
-    }
-
-    val tzIdDefault = java.util.TimeZone.getDefault().id!!
-    val tzDefault = tzRegistry.getTimeZone(tzIdDefault)!!
-
     val exDateGenerator: ((DateList<*>) -> ExDate<*>) = { dateList ->
         ExDate(dateList)
     }
 
-    // androidifyTimeZone
-    // DateListProperty - date
-
-    /*@Test
-    fun testAndroidifyTimeZone_DateListProperty_Date() {
-        // dates (without time) should be ignored
-        val rDate = RDate(DateList("20150101,20150102", Value.DATE))
-        AndroidTimeUtils.androidifyTimeZone(rDate)
-        assertEquals(1420070400000L, rDate.dates[0].time)
-        assertEquals(1420156800000L, rDate.dates[1].time)
-        assertNull(rDate.timeZone)
-        assertEquals(Value.DATE, rDate.dates.type)
-        assertNull(rDate.dates.timeZone)
-        assertFalse(rDate.dates.isUtc)
-    }
-
-    // androidifyTimeZone
-    // DateListProperty - date-time
-
-    @Test
-    fun testAndroidifyTimeZone_DateListProperty_KnownTimeZone() {
-        // times with known time zone should be unchanged
-        val rDate = RDate(DateList("20150101T150000,20150102T150000", Value.DATE_TIME, tzToronto))
-        AndroidTimeUtils.androidifyTimeZone(rDate)
-        assertEquals(1420142400000L, rDate.dates[0].time)
-        assertEquals(1420228800000L, rDate.dates[1].time)
-        assertEquals(tzToronto, rDate.timeZone)
-        assertEquals(Value.DATE_TIME, rDate.dates.type)
-        assertEquals(tzToronto, rDate.dates.timeZone)
-        assertFalse(rDate.dates.isUtc)
-    }
-
-    @Test
-    fun testAndroidifyTimeZone_DateListProperty_UnknownTimeZone() {
-        // time zone that is not available on Android systems should be rewritten to system default
-        val rDate = RDate(DateList("20150101T031000,20150102T031000", Value.DATE_TIME, tzCustom))
-        AndroidTimeUtils.androidifyTimeZone(rDate)
-        assertEquals(DateTime("20150101T031000", tzCustom).time, rDate.dates[0].time)
-        assertEquals(DateTime("20150102T031000", tzCustom).time, rDate.dates[1].time)
-        assertEquals(tzIdDefault, rDate.timeZone.id)
-        assertEquals(Value.DATE_TIME, rDate.dates.type)
-        assertEquals(tzIdDefault, rDate.dates.timeZone.id)
-        assertFalse(rDate.dates.isUtc)
-    }
-
-    @Test
-    fun testAndroidifyTimeZone_DateListProperty_FloatingTime() {
-        // times with floating time should be treated as system default time zone
-        val rDate = RDate(DateList("20150101T031000,20150102T031000", Value.DATE_TIME))
-        AndroidTimeUtils.androidifyTimeZone(rDate)
-        assertEquals(DateTime("20150101T031000", tzDefault).time, rDate.dates[0].time)
-        assertEquals(DateTime("20150102T031000", tzDefault).time, rDate.dates[1].time)
-        assertEquals(tzIdDefault, rDate.timeZone.id)
-        assertEquals(Value.DATE_TIME, rDate.dates.type)
-        assertEquals(tzIdDefault, rDate.dates.timeZone.id)
-        assertFalse(rDate.dates.isUtc)
-    }
-
-    @Test
-    fun testAndroidifyTimeZone_DateListProperty_UTC() {
-        // times with UTC should be unchanged
-        val rDate = RDate(DateList("20150101T031000Z,20150102T031000Z", Value.DATE_TIME))
-        AndroidTimeUtils.androidifyTimeZone(rDate)
-        assertEquals(DateTime("20150101T031000Z").time, rDate.dates[0].time)
-        assertEquals(DateTime("20150102T031000Z").time, rDate.dates[1].time)
-        assertNull(rDate.timeZone)
-        assertEquals(Value.DATE_TIME, rDate.dates.type)
-        assertNull(rDate.dates.timeZone)
-        assertTrue(rDate.dates.isUtc)
-    }
-
-    // androidifyTimeZone
-    // DateListProperty - period-explicit
-
-    @Test
-    fun testAndroidifyTimeZone_DateListProperty_Period_FloatingTime() {
-        // times with floating time should be treated as system default time zone
-        val rDate = RDate(PeriodList("19970101T180000/19970102T070000,20220103T000000/20220108T000000"))
-        AndroidTimeUtils.androidifyTimeZone(rDate)
-        assertEquals(
-            setOf(
-                Period(DateTime("19970101T18000000"), DateTime("19970102T07000000")),
-                Period(DateTime("20220103T000000"), DateTime("20220108T000000"))
-            ),
-            rDate.periods
-        )
-        assertNull(rDate.timeZone)
-        assertNull(rDate.periods.timeZone)
-        assertTrue(rDate.periods.isUtc)
-    }
-
-    @Test
-    fun testAndroidifyTimeZone_DateListProperty_Period_KnownTimezone() {
-        // periods with known time zone should be unchanged
-        val rDate = RDate(PeriodList("19970101T180000/19970102T070000,19970102T180000/19970108T090000"))
-        rDate.periods.timeZone = tzToronto
-        AndroidTimeUtils.androidifyTimeZone(rDate)
-        assertEquals(
-            setOf(Period("19970101T180000/19970102T070000"), Period("19970102T180000/19970108T090000")),
-            mutableSetOf<Period>().also { it.addAll(rDate.periods) }
-        )
-        assertEquals(tzToronto, rDate.periods.timeZone)
-        assertNull(rDate.timeZone)
-        assertFalse(rDate.dates.isUtc)
-    }
-
-    @Test
-    fun testAndroidifyTimeZone_DateListProperty_Periods_UnknownTimeZone() {
-        // time zone that is not available on Android systems should be rewritten to system default
-        val rDate = RDate(PeriodList("19970101T180000/19970102T070000,19970102T180000/19970108T090000"))
-        rDate.periods.timeZone = tzCustom
-        AndroidTimeUtils.androidifyTimeZone(rDate)
-        assertEquals(
-            setOf(Period("19970101T180000/19970102T070000"), Period("19970102T180000/19970108T090000")),
-            mutableSetOf<Period>().also { it.addAll(rDate.periods) }
-        )
-        assertEquals(tzIdDefault, rDate.periods.timeZone.id)
-        assertNull(rDate.timeZone)
-        assertFalse(rDate.dates.isUtc)
-    }
-
-    @Test
-    fun testAndroidifyTimeZone_DateListProperty_Period_UTC() {
-        // times with UTC should be unchanged
-        val rDate = RDate(PeriodList("19970101T180000Z/19970102T070000Z,20220103T0000Z/20220108T0000Z"))
-        AndroidTimeUtils.androidifyTimeZone(rDate)
-        assertEquals(
-            setOf(
-                Period(DateTime("19970101T180000Z"), DateTime("19970102T070000Z")),
-                Period(DateTime("20220103T0000Z"), DateTime("20220108T0000Z"))
-            ),
-            rDate.periods
-        )
-        assertTrue(rDate.periods.isUtc)
-    }
-
-    // androidifyTimeZone
-    // DateListProperty - period-start
-
-    @Test
-    fun testAndroidifyTimeZone_DateListProperty_PeriodStart_UTC() {
-        // times with UTC should be unchanged
-        val rDate = RDate(PeriodList("19970101T180000Z/PT5H30M,20220103T0000Z/PT2H30M10S"))
-        AndroidTimeUtils.androidifyTimeZone(rDate)
-        assertEquals(
-            setOf(
-                Period(DateTime("19970101T180000Z"), Duration.parse("PT5H30M")),
-                Period(DateTime("20220103T0000Z"), Duration.parse("PT2H30M10S"))
-            ),
-            rDate.periods
-        )
-        assertTrue(rDate.periods.isUtc)
-    }
-
-    // storageTzId
-
-    @Test
-    fun testStorageTzId_Date() =
-        assertEquals(AndroidTimeUtils.TZID_UTC, AndroidTimeUtils.storageTzId(DtStart(Date("20150101"))))
-
-    @Test
-    fun testStorageTzId_FloatingTime() =
-        assertEquals(TimeZone.getDefault().id, AndroidTimeUtils.storageTzId(DtStart(DateTime("20150101T000000"))))
-*/
 
     // androidStringToRecurrenceSets
 
@@ -357,7 +173,6 @@ class AndroidTimeUtilsTest {
 
     // recurrenceSetsToOpenTasksString
 
-    /*
     @Test
     fun testRecurrenceSetsToOpenTasksString_UtcTimes() {
         val list = ArrayList<DateListProperty<Temporal>>(1)
@@ -429,7 +244,7 @@ class AndroidTimeUtilsTest {
         assertEquals(Duration.parse("P11DT3H2M1S"), AndroidTimeUtils.parseDuration("P1S2M3H4D1W"))
         assertEquals(Duration.parse("PT1H0M10S"), AndroidTimeUtils.parseDuration("1H10S"))
     }
-*/
+
 
     @Test
     fun `toTimestamp on LocalDate should use start of UTC day`() {


### PR DESCRIPTION
Remove now obsolete commented out tests and enable the rest.

I missed this when working on PR #257. I retroactively declare this to be part of #242 :smile: 