### PR TITLE
Make `GrantPermissionOrSkipRule` work as intended on Android 7

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/synctools/test/GrantPermissionOrSkipRule.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/test/GrantPermissionOrSkipRule.kt
@@ -7,6 +7,7 @@
 package at.bitfire.synctools.test
 
 import androidx.test.rule.GrantPermissionRule
+import junit.framework.AssertionFailedError
 import org.junit.Assume
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -28,6 +29,12 @@ class GrantPermissionOrSkipRule(permissions: Set<String>): TestRule {
                 val innerStatement = grantRule.apply(base, description)
                 try {
                     innerStatement.evaluate()
+                } catch (e: AssertionFailedError) {
+                    if (e.message == "Failed to grant permissions, see logcat for details") {
+                        Assume.assumeNoException(e)
+                    } else {
+                        throw e
+                    }
                 } catch (e: SecurityException) {
                     Assume.assumeNoException(e)
                 }


### PR DESCRIPTION
While working on #244 I noticed that tests fail on my Android 7 device when one of the task apps is not installed. This changes `GrantPermissionOrSkipRule` to ignore a test when the permission couldn't be granted.