### PR TITLE
Don't try to add empty attendee caladdress

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
@@ -830,7 +830,8 @@ open class JtxICalObject(
 
         attendees.forEach { attendee ->
             val attendeeProp = net.fortuna.ical4j.model.property.Attendee().apply {
-                this.calAddress = URI(attendee.caladdress)
+                if(attendee.caladdress?.isNotEmpty() == true)
+                    this.calAddress = URI(attendee.caladdress)
 
                 attendee.cn?.let {
                     this += Cn(it)


### PR DESCRIPTION
Closes https://github.com/bitfireAT/synctools/issues/211

The caladdress for attendees usually contains the email with "mailto" format. It is however optional for attendees and could be empty or null. We were parsing the nullable email caladdress value for attendees using `java.net.URI`, which then threw. Adding a null-check solves the issue and not adding the caladress when it is not present is ok, since it's optional. We don't always have to infer it.

I have not added a test for the modified method `addProperties` here, since the JtxICalObject is due for refactoring to the new builder/handler pattern with better tests soon anyways.