### PR TITLE
Add gradle-daemon-jvm.properties and update Java references

### DIFF
--- a/.github/workflows/build-kdoc.yml
+++ b/.github/workflows/build-kdoc.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 21   # keep in sync with gradle/gradle-daemon-jvm.properties
       - uses: gradle/actions/setup-gradle@v5
 
       - name: Build KDoc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 21   # keep in sync with gradle/gradle-daemon-jvm.properties
 
       # See https://community.gradle.org/github-actions/docs/setup-gradle/ for more information
       - uses: gradle/actions/setup-gradle@v5            # creates build cache when on main branch
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 21   # keep in sync with gradle/gradle-daemon-jvm.properties
       - uses: gradle/actions/setup-gradle@v5
         with:
           cache-encryption-key: ${{ secrets.gradle_encryption_key }}
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 21   # keep in sync with gradle/gradle-daemon-jvm.properties
 
       - name: Enable KVM group perms
         run: |
@@ -79,4 +79,4 @@ jobs:
           key: avd-${{ hashFiles('lib/build.gradle.kts') }}   # gradle-managed devices are defined there
 
       - name: Run device tests
-        run: ./gradlew --no-daemon virtualCheck
+        run: ./gradlew virtualCheck

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -1,0 +1,4 @@
+#
+# https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:configuring_daemon_jvm
+#
+toolchainVersion=21

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 jdk:
-  - openjdk21
+  - openjdk21   # keep in sync with gradle/gradle-daemon-jvm.properties
 before_install:
   - sdk install java 21-open
   - sdk use java 21-open


### PR DESCRIPTION
Adds `gradle-daemon-jvm.properties` file and synchronizes Java 21 references across the project.