### PR TITLE
Download tasks app APKs from F-Droid and install as instrumented tests dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,34 +83,17 @@ jobs:
             # Extract package name and suggested version code
             package_name=$(echo "$response" | jq -r '.packageName')
             suggested_version_code=$(echo "$response" | jq -r '.suggestedVersionCode')
-            
             if [ -z "$package_name" ] || [ "$package_name" == "null" ]; then
               echo "Error: Could not get package info for $pkg"
-              exit 1
+              continue
             fi
             
             # Download the APK
-            apk_url="https://f-droid.org/repo/$package_name_$suggested_version_code.apk"
+            apk_url="https://f-droid.org/repo/${package_name}_${suggested_version_code}.apk"
             apk_file="${{ env.apk-dir }}/${package_name}_latest.apk"
-            
             echo "Downloading APK from: $apk_url into $apk_file"
             curl -Lo "$apk_file" "$apk_url"
-            
-            if [ -f "$apk_file" ]; then
-              echo "Successfully downloaded: $apk_file"
-              ls -la "$apk_file"
-            else
-              echo "Error: Failed to download APK for $pkg"
-              exit 1
-            fi
           done
-          
-          # List all downloaded APKs
-          echo "Downloaded APKs:"
-          ls -la ${{ env.apk-dir }}/
-          
-          # Set environment variable for later steps
-          echo "FDROID_APKS_DIR=$(pwd)/${{ env.apk-dir }}" >> $GITHUB_ENV
 
       - name: Enable KVM group perms
         run: |

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -134,10 +134,14 @@ dependencies {
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.test.runner)
 
-    // install third-party APKs for instrumented test
-    androidTestUtil(files("apk/at.techbee.jtx_latest.apk"))
-    androidTestUtil(files("apk/org.dmfs.tasks_latest.apk"))
-    androidTestUtil(files("apk/org.tasks_latest.apk"))
+    // install third-party APKs for instrumented tests (if available)
+    val apkDir = file("apk")
+    if (apkDir.exists() && apkDir.isDirectory) {
+        val apkFiles = apkDir.listFiles { file -> file.isFile && file.name.endsWith(".apk") }
+        if (apkFiles != null && apkFiles.isNotEmpty()) {
+            androidTestUtil(files(apkFiles))
+        }
+    }
 
     // unit tests
     testImplementation(libs.junit)


### PR DESCRIPTION
Without PR (main): [194 skipped tests](https://github.com/bitfireAT/synctools/actions/runs/23982872154/job/69950008419)
With PR: [0 skipped tests](https://github.com/bitfireAT/synctools/actions/runs/23984936338/job/69955247042)

1. The `tests.yml` workflow now downloads the latest F-Droid APKs (unfortunately we have to fetch & parse the version codes befirst) into `lib/apk/`.
2. In `lib/build.gradle.kts`, the APK files in `lib/apk/` are defined as ``androidTestUtil(files(apkFiles))`` dependency. This is a [very hidden and badly documented feature](https://developer.android.com/build/releases/agp-3-0-0-release-notes) that 
    
    >allows you to install another test helper APK before running your instrumentation tests
    
    which is exactly what we need.