### PR TITLE
Add `Temporal.toInstant()` and simplify `androidTimeZoneId()` to simplify temporal conversion logic

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapper.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapper.kt
@@ -7,13 +7,12 @@
 package at.bitfire.synctools.mapping.calendar.builder
 
 import at.bitfire.ical4android.util.DateUtils
+import at.bitfire.ical4android.util.TimeApiExtensions.toLocalDate
 import at.bitfire.synctools.util.AndroidTimeUtils.toInstant
-import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import at.bitfire.synctools.util.AndroidTimeUtils.toZonedDateTime
 import net.fortuna.ical4j.model.Property
-import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -64,57 +63,30 @@ object AndroidRecurrenceMapper {
         */
         val utcDateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.ROOT)
         val dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss", Locale.ROOT)
-        val convertedDates = mutableListOf<ZonedDateTime>()
         val allDay = DateUtils.isDate(startDate)
 
         // use time zone of first entry for the whole set; null for UTC
         val zoneId = (dates.firstOrNull() as? ZonedDateTime)?.zone
+        val targetZone: ZoneId = zoneId ?: ZoneOffset.UTC
 
-        for (date in dates) {
-            if (date is LocalDate) {
-                // RDATE/EXDATE is DATE
-                if (allDay) {
-                    // DTSTART is DATE; DATE values have to be returned as <date>T000000Z for Android
-
-                    convertedDates.add(date.atStartOfDay().atZone(ZoneOffset.UTC))
-                } else {
-                    // DTSTART is DATE-TIME; amend DATE-TIME with clock time from DTSTART
+        val convertedDates = dates.map { date ->
+            when {
+                allDay -> {
+                    // DTSTART is DATE; store as <date>T000000Z for Android
+                    date.toLocalDate().atStartOfDay(ZoneOffset.UTC)
+                }
+                date is LocalDate -> {
+                    // RDATE/EXDATE is DATE, DTSTART is DATE-TIME; amend with clock time from DTSTART
                     val zonedStartDate = startDate.toZonedDateTime()
-                    val amendedDate = ZonedDateTime.of(
-                        date,
-                        zonedStartDate.toLocalTime(),
-                        zonedStartDate.zone
-                    )
-
-                    val convertedDate = if (zoneId != null) {
-                        amendedDate.withZoneSameInstant(zoneId)
-                    } else {
-                        amendedDate.withZoneSameInstant(ZoneOffset.UTC)
-                    }
-
-                    convertedDates.add(convertedDate)
+                    ZonedDateTime.of(
+                        /* date = */ date,
+                        /* time = */ zonedStartDate.toLocalTime(),
+                        /* zone = */ zonedStartDate.zone
+                    ).withZoneSameInstant(targetZone)
                 }
-
-            } else {
-                // RDATE/EXDATE is DATE-TIME
-                val convertedDate = if (allDay) {
-                    // DTSTART is DATE
-                    val localDate = if (date is LocalDateTime) {
-                        date.toLocalDate()
-                    } else {
-                        date.toInstant().atZone(ZoneOffset.UTC).toLocalDate()
-                    }
-                    localDate.atStartOfDay().atZone(ZoneOffset.UTC)
-                } else {
-                    // DTSTART is DATE-TIME
-                    val instant = date.toInstant()
-                    if (zoneId != null) {
-                        instant.atZone(zoneId)
-                    } else {
-                        instant.atZone(ZoneOffset.UTC)
-                    }
-                }
-                convertedDates.add(convertedDate)
+                else ->
+                    // Both DATE-TIME
+                    date.toInstant().atZone(targetZone)
             }
         }
 

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapper.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapper.kt
@@ -75,8 +75,8 @@ object AndroidRecurrenceMapper {
                     // DTSTART is DATE; store as <date>T000000Z for Android
                     date.toLocalDate().atStartOfDay(ZoneOffset.UTC)
                 }
-                date is LocalDate -> {
-                    // RDATE/EXDATE is DATE, DTSTART is DATE-TIME; amend with clock time from DTSTART
+                /* allDay is already covered above, so implicitly: !allDay && */ date is LocalDate -> {
+                    // DTSTART is DATE-TIME, RDATE/EXDATE is DATE; amend with clock time from DTSTART
                     val zonedStartDate = startDate.toZonedDateTime()
                     ZonedDateTime.of(
                         /* date = */ date,

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapper.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapper.kt
@@ -7,6 +7,7 @@
 package at.bitfire.synctools.mapping.calendar.builder
 
 import at.bitfire.ical4android.util.DateUtils
+import at.bitfire.synctools.util.AndroidTimeUtils.toInstant
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import at.bitfire.synctools.util.AndroidTimeUtils.toZonedDateTime
 import net.fortuna.ical4j.model.Property
@@ -101,12 +102,12 @@ object AndroidRecurrenceMapper {
                     val localDate = if (date is LocalDateTime) {
                         date.toLocalDate()
                     } else {
-                        Instant.ofEpochMilli(date.toTimestamp()).atZone(ZoneOffset.UTC).toLocalDate()
+                        date.toInstant().atZone(ZoneOffset.UTC).toLocalDate()
                     }
                     localDate.atStartOfDay().atZone(ZoneOffset.UTC)
                 } else {
                     // DTSTART is DATE-TIME
-                    val instant = Instant.ofEpochMilli(date.toTimestamp())
+                    val instant = date.toInstant()
                     if (zoneId != null) {
                         instant.atZone(zoneId)
                     } else {

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapper.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapper.kt
@@ -73,9 +73,17 @@ object AndroidRecurrenceMapper {
             when {
                 allDay -> {
                     // DTSTART is DATE; store as <date>T000000Z for Android
-                    date.toLocalDate().atStartOfDay(ZoneOffset.UTC)
+                    if (date is LocalDate) {
+                        // RDATE/EXDATE is DATE
+                        date.atStartOfDay(ZoneOffset.UTC)
+                    } else {
+                        // RDATE/EXDATE is DATE-TIME, drop time part
+                        date.toLocalDate().atStartOfDay(ZoneOffset.UTC)
+                    }
                 }
-                /* allDay is already covered above, so implicitly: !allDay && */ date is LocalDate -> {
+                // from now on, we know that DTSTART is DATE-TIME
+
+                date is LocalDate -> {
                     // DTSTART is DATE-TIME, RDATE/EXDATE is DATE; amend with clock time from DTSTART
                     val zonedStartDate = startDate.toZonedDateTime()
                     ZonedDateTime.of(

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/DurationBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/DurationBuilder.kt
@@ -16,13 +16,13 @@ import at.bitfire.ical4android.util.TimeApiExtensions.toLocalDate
 import at.bitfire.ical4android.util.TimeApiExtensions.toRfc5545Duration
 import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
 import at.bitfire.synctools.icalendar.requireDtStart
+import at.bitfire.synctools.util.AndroidTimeUtils.toInstant
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
 import java.time.Duration
-import java.time.Instant
 import java.time.Period
 import java.time.temporal.Temporal
 import java.time.temporal.TemporalAmount
@@ -70,7 +70,7 @@ class DurationBuilder: AndroidEntityBuilder {
 
         The calendar provider accepts every DURATION that `com.android.calendarcommon2.Duration` can parse,
         which is weeks, days, hours, minutes and seconds, like for the RFC 5545 duration. */
-        val durationStr = alignedDuration.toRfc5545Duration(Instant.ofEpochMilli(startDate.toTimestamp()))
+        val durationStr = alignedDuration.toRfc5545Duration(startDate.toInstant())
         values.put(Events.DURATION, durationStr)
     }
 
@@ -101,7 +101,7 @@ class DurationBuilder: AndroidEntityBuilder {
             // DTSTART is DATE-TIME
             return if (amount is Period) {
                 // amount is Period, change to Duration instead
-                amount.toDuration(Instant.ofEpochMilli(startDate.toTimestamp()))
+                amount.toDuration(startDate.toInstant())
             } else {
                 // amount is already Duration
                 amount

--- a/lib/src/main/kotlin/at/bitfire/synctools/util/AndroidTimeUtils.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/util/AndroidTimeUtils.kt
@@ -100,26 +100,28 @@ object AndroidTimeUtils {
      *         - the specified time zone ID for date-times with given time zone
      *         - the currently set default time zone ID for floating date-times
      */
-    fun Temporal.androidTimezoneId(): String {
-        return if (TemporalAdapter.isDateTimePrecision(this)) {
-            if (TemporalAdapter.isUtc(this)) {
-                TZID_UTC
-            } else if (TemporalAdapter.isFloating(this)) {
-                ZoneId.systemDefault().id
-            } else {
-                require(this is ZonedDateTime) { "date-time which is neither floating nor UTC must be a ZonedDateTime" }
-
-                val timezoneId = this.zone.id
-                require(!timezoneId.startsWith("ical4j")) {
-                    "ical4j ZoneIds are not supported. Call DatePropertyTzMapper.normalizedDate() " +
-                            "before passing a date to this function."
-                }
-
-                timezoneId
-            }
-        } else {
-            // For all-day events EventsColumns.EVENT_TIMEZONE must be "UTC".
+    fun Temporal.androidTimezoneId(): String = when {
+        !TemporalAdapter.isDateTimePrecision(this) ->   // date
             TZID_UTC
+        // from here on we know that the Temporal has date-time precision
+
+        TemporalAdapter.isUtc(this) ->                  // UTC date-time
+            TZID_UTC
+
+        TemporalAdapter.isFloating(this) ->             // floating date-time
+            ZoneId.systemDefault().id
+
+        else -> {
+            // date-time with timezone
+            require(this is ZonedDateTime) { "date-time which is neither floating nor UTC must be a ZonedDateTime" }
+
+            val timezoneId = this.zone.id
+            require(!timezoneId.startsWith("ical4j")) {
+                "ical4j ZoneIds are not supported. Call DatePropertyTzMapper.normalizedDate() " +
+                        "before passing a date to this function."
+            }
+
+            timezoneId
         }
     }
 

--- a/lib/src/main/kotlin/at/bitfire/synctools/util/AndroidTimeUtils.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/util/AndroidTimeUtils.kt
@@ -8,6 +8,10 @@ package at.bitfire.synctools.util
 
 import at.bitfire.ical4android.util.TimeApiExtensions
 import at.bitfire.ical4android.util.TimeApiExtensions.toLocalDate
+import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
+import at.bitfire.synctools.util.AndroidTimeUtils.androidTimezoneId
+import at.bitfire.synctools.util.AndroidTimeUtils.toInstant
+import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import net.fortuna.ical4j.model.CalendarDateFormat
 import net.fortuna.ical4j.model.DateList
 import net.fortuna.ical4j.model.TemporalAdapter
@@ -17,7 +21,6 @@ import net.fortuna.ical4j.model.parameter.TzId
 import net.fortuna.ical4j.model.parameter.Value
 import net.fortuna.ical4j.model.property.DateListProperty
 import net.fortuna.ical4j.model.property.RDate
-import net.fortuna.ical4j.util.TimeZones
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
@@ -30,6 +33,7 @@ import java.time.ZonedDateTime
 import java.time.temporal.ChronoField
 import java.time.temporal.Temporal
 import java.time.temporal.TemporalAmount
+import java.time.temporal.UnsupportedTemporalTypeException
 import java.util.logging.Logger
 import kotlin.jvm.optionals.getOrDefault
 
@@ -48,29 +52,41 @@ object AndroidTimeUtils {
 
 
     /**
-     * Converts this [Temporal] to the timestamp that should be used when writing an event to the
-     * Android calendar provider or task providers.
+     * Converts this [Temporal] to an [Instant] that should be used when working with temporal values.
+     *
+     * Local dates are treated as UTC (start of day).
+     * Local date-times are treated as in the system default timezone.
+     *
+     * Supports [LocalDate], [LocalDateTime], [OffsetDateTime], [ZonedDateTime] and [Instant].
+     *
+     * @return corresponding [Instant]
+     * @throws UnsupportedTemporalTypeException on unsupported [Temporal] types
      */
-    fun Temporal.toTimestamp(): Long {
-        val epochSeconds = when (this) {
-            is LocalDate -> atStartOfDay().atZone(TimeZones.getDateTimeZone().toZoneId()).toEpochSecond()
-            is LocalDateTime -> atZone(TimeZones.getDefault().toZoneId()).toEpochSecond()
-            is OffsetDateTime -> toEpochSecond()
-            is ZonedDateTime -> toEpochSecond()
-            is Instant -> epochSecond
-            else -> error("Unsupported Temporal type: ${this::class.qualifiedName}")
+    fun Temporal.toInstant(): Instant =
+        when (this) {
+            is LocalDate -> atStartOfDay(ZoneOffset.UTC).toInstant()
+            is LocalDateTime -> atZone(ZoneId.systemDefault()).toInstant()
+            is OffsetDateTime -> toInstant()
+            is ZonedDateTime -> toInstant()
+            is Instant -> this
+            else -> throw UnsupportedTemporalTypeException("Can't convert ${this::class.qualifiedName} to Instant")
         }
 
-        return epochSeconds * 1000L
-    }
+    /**
+     * Same as [toInstant], but returns a UNIX timestamp (in milliseconds) instead of an [Instant].
+     */
+    fun Temporal.toTimestamp(): Long =
+        toInstant().epochSecond * 1000
 
     /**
      * Converts this [Temporal] to a [ZonedDateTime] that is created from the timestamp returned by
      * [toTimestamp] and the time zone returned by [androidTimezoneId].
      */
-    fun Temporal.toZonedDateTime(): ZonedDateTime {
-        return Instant.ofEpochMilli(toTimestamp()).atZone(ZoneId.of(androidTimezoneId()))
-    }
+    fun Temporal.toZonedDateTime(): ZonedDateTime =
+        ZonedDateTime.ofInstant(
+            toInstant(),
+            ZoneId.of(androidTimezoneId())
+        )
 
     /**
      * Returns the timezone ID that should be used when writing an event to the Android calendar
@@ -91,7 +107,7 @@ object AndroidTimeUtils {
             } else if (TemporalAdapter.isFloating(this)) {
                 ZoneId.systemDefault().id
             } else {
-                require(this is ZonedDateTime) { "Non-floating date-time must be a ZonedDateTime" }
+                require(this is ZonedDateTime) { "date-time which is neither floating nor UTC must be a ZonedDateTime" }
 
                 val timezoneId = this.zone.id
                 require(!timezoneId.startsWith("ical4j")) {

--- a/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
@@ -26,6 +26,7 @@ import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.RDate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import java.io.StringReader
@@ -41,7 +42,6 @@ import java.time.ZonedDateTime
 import java.time.chrono.JapaneseDate
 import java.time.format.DateTimeParseException
 import java.time.temporal.Temporal
-import java.time.temporal.UnsupportedTemporalTypeException
 import java.time.zone.ZoneRulesException
 import java.util.Optional
 
@@ -292,46 +292,66 @@ class AndroidTimeUtilsTest {
         assertEquals(inputTimestamp, timestamp)
     }
 
-    @Test(expected = UnsupportedTemporalTypeException::class)
+    @Test
     fun `toTimestamp on unsupported type`() {
-        JapaneseDate.now().toTimestamp()
+        try {
+            JapaneseDate.now().toTimestamp()
+
+            fail("Expected exception")
+        } catch (e: IllegalStateException) {
+            assertEquals("Unsupported Temporal type: java.time.chrono.JapaneseDate", e.message)
+        }
     }
 
 
     @Test
     fun `androidTimezoneId on LocalDate`() {
         val date = LocalDate.now()
+
         val timezoneId = date.androidTimezoneId()
+
         assertEquals("UTC", timezoneId)
     }
 
     @Test
     fun `androidTimezoneId on LocalDateTime`() {
         val date = LocalDateTime.now()
+
         val timezoneId = date.androidTimezoneId()
+
         assertEquals(tzRule.defaultZoneId.id, timezoneId)
     }
 
     @Test
     fun `androidTimezoneId on ZonedDateTime`() {
         val date = LocalDateTime.now().atZone(ZoneId.of("Europe/Dublin"))
+
         val timezoneId = date.androidTimezoneId()
+
         assertEquals("Europe/Dublin", timezoneId)
     }
 
     @Test
     fun `androidTimezoneId on Instant`() {
         val date = Instant.now()
+
         val timezoneId = date.androidTimezoneId()
+
         assertEquals("UTC", timezoneId)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `androidTimezoneId on OffsetDateTime`() {
-        OffsetDateTime.now().androidTimezoneId()
+        try {
+            OffsetDateTime.now().androidTimezoneId()
+
+            fail("Expected exception")
+        } catch (e: IllegalArgumentException) {
+            assertEquals("Non-floating date-time must be a ZonedDateTime", e.message)
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `androidTimezoneId on ZonedDateTime from ical4j`() {
         val cal = CalendarBuilder().build(StringReader(
             """
@@ -356,7 +376,17 @@ class AndroidTimeUtilsTest {
         val vEvent = cal.getComponent<VEvent>(Component.VEVENT).get()
         val date = vEvent.requireDtStart<Temporal>().date
 
-        date.androidTimezoneId()
+        try {
+            date.androidTimezoneId()
+
+            fail("Expected exception")
+        } catch (e: IllegalArgumentException) {
+            assertEquals(
+                "ical4j ZoneIds are not supported. Call DatePropertyTzMapper.normalizedDate() " +
+                        "before passing a date to this function.",
+                e.message
+            )
+        }
     }
 
 }

--- a/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
@@ -42,6 +42,7 @@ import java.time.ZonedDateTime
 import java.time.chrono.JapaneseDate
 import java.time.format.DateTimeParseException
 import java.time.temporal.Temporal
+import java.time.temporal.UnsupportedTemporalTypeException
 import java.time.zone.ZoneRulesException
 import java.util.Optional
 
@@ -292,15 +293,9 @@ class AndroidTimeUtilsTest {
         assertEquals(inputTimestamp, timestamp)
     }
 
-    @Test
+    @Test(expected = UnsupportedTemporalTypeException::class)
     fun `toTimestamp on unsupported type`() {
-        try {
-            JapaneseDate.now().toTimestamp()
-
-            fail("Expected exception")
-        } catch (e: IllegalStateException) {
-            assertEquals("Unsupported Temporal type: java.time.chrono.JapaneseDate", e.message)
-        }
+        JapaneseDate.now().toTimestamp()
     }
 
 
@@ -340,15 +335,9 @@ class AndroidTimeUtilsTest {
         assertEquals("UTC", timezoneId)
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException::class)
     fun `androidTimezoneId on OffsetDateTime`() {
-        try {
-            OffsetDateTime.now().androidTimezoneId()
-
-            fail("Expected exception")
-        } catch (e: IllegalArgumentException) {
-            assertEquals("Non-floating date-time must be a ZonedDateTime", e.message)
-        }
+        OffsetDateTime.now().androidTimezoneId()
     }
 
     @Test

--- a/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
@@ -26,7 +26,6 @@ import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.RDate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import java.io.StringReader
@@ -302,36 +301,28 @@ class AndroidTimeUtilsTest {
     @Test
     fun `androidTimezoneId on LocalDate`() {
         val date = LocalDate.now()
-
         val timezoneId = date.androidTimezoneId()
-
         assertEquals("UTC", timezoneId)
     }
 
     @Test
     fun `androidTimezoneId on LocalDateTime`() {
         val date = LocalDateTime.now()
-
         val timezoneId = date.androidTimezoneId()
-
         assertEquals(tzRule.defaultZoneId.id, timezoneId)
     }
 
     @Test
     fun `androidTimezoneId on ZonedDateTime`() {
         val date = LocalDateTime.now().atZone(ZoneId.of("Europe/Dublin"))
-
         val timezoneId = date.androidTimezoneId()
-
         assertEquals("Europe/Dublin", timezoneId)
     }
 
     @Test
     fun `androidTimezoneId on Instant`() {
         val date = Instant.now()
-
         val timezoneId = date.androidTimezoneId()
-
         assertEquals("UTC", timezoneId)
     }
 
@@ -340,7 +331,7 @@ class AndroidTimeUtilsTest {
         OffsetDateTime.now().androidTimezoneId()
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException::class)
     fun `androidTimezoneId on ZonedDateTime from ical4j`() {
         val cal = CalendarBuilder().build(StringReader(
             """
@@ -365,17 +356,7 @@ class AndroidTimeUtilsTest {
         val vEvent = cal.getComponent<VEvent>(Component.VEVENT).get()
         val date = vEvent.requireDtStart<Temporal>().date
 
-        try {
-            date.androidTimezoneId()
-
-            fail("Expected exception")
-        } catch (e: IllegalArgumentException) {
-            assertEquals(
-                "ical4j ZoneIds are not supported. Call DatePropertyTzMapper.normalizedDate() " +
-                        "before passing a date to this function.",
-                e.message
-            )
-        }
+        date.androidTimezoneId()
     }
 
 }


### PR DESCRIPTION
This pull request includes several improvements to the temporal conversion logic:

- Adds `Temporal.toInstant()` method and improves exception handling
- Replaces `Instant.ofEpochMilli(toTimestamp())` with `toInstant()` for cleaner conversions
- Refactors `androidTimezoneId()` to use a `when` expression for better readability
- Simplifies recurrence date conversion logic

No test changes required because the logic is only simplified, but not changed.