### PR TITLE
Add count methods to storage collection classes

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarTest.kt
@@ -1,5 +1,7 @@
 /*
- * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar
@@ -111,6 +109,67 @@ class AndroidCalendarTest {
         // verify that event has been inserted
         val result = calendar.getEvent(id)!!
         assertEntitiesEqual(entity, result, onlyFieldsInExpected = true)
+    }
+
+    @Test
+    fun testCountEvents_empty() {
+        // Test counting when calendar is empty
+        val count = calendar.countEvents(null, null)
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun testCountEvents_withEvents() {
+        // Add multiple events and test counting
+        calendar.addEvent(Entity(contentValuesOf(
+            Events.CALENDAR_ID to calendar.id,
+            Events.DTSTART to now,
+            Events.DTEND to now + 3600000,
+            Events.TITLE to "Event 1"
+        )))
+        calendar.addEvent(Entity(contentValuesOf(
+            Events.CALENDAR_ID to calendar.id,
+            Events.DTSTART to now + 3600000,
+            Events.DTEND to now + 3600000*2,
+            Events.TITLE to "Event 2"
+        )))
+        
+        val count = calendar.countEvents(null, null)
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun testCountEvents_filterMatch() {
+        // Test counting with WHERE clause
+        calendar.addEvent(Entity(contentValuesOf(
+            Events.CALENDAR_ID to calendar.id,
+            Events.DTSTART to now,
+            Events.DTEND to now + 3600000,
+            Events.TITLE to "Filter Test 1"
+        )))
+        calendar.addEvent(Entity(contentValuesOf(
+            Events.CALENDAR_ID to calendar.id,
+            Events.DTSTART to now + 3600000,
+            Events.DTEND to now + 3600000*2,
+            Events.TITLE to "Filter Test 2"
+        )))
+        
+        val filteredCount = calendar.countEvents("${Events.DTSTART}=?", arrayOf(now.toString()))
+        assertEquals(1, filteredCount)
+    }
+
+    @Test
+    fun testCountEvents_filterNoMatch() {
+        // Test counting with filter that matches nothing
+        calendar.addEvent(Entity(contentValuesOf(
+            Events.CALENDAR_ID to calendar.id,
+            Events.DTSTART to now,
+            Events.DTEND to now + 3600000,
+            Events.TITLE to "Test Event"
+        )))
+        
+        val noMatchCount = calendar.countEvents("${Events.DTSTART}=?", arrayOf((now + 86400000).toString()))
+        assertEquals(0, noMatchCount)
     }
 
     @Test

--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -72,7 +72,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
             DmfsTask(taskList, task2, "sync-id-2", null, 0).add()
             
             // Test counting with UID filter
-            val filteredCount = taskList.countTasks("${TaskContract.Tasks._SYNC_ID}=?", arrayOf("sync-id-1"))
+            val filteredCount = taskList.countTasks("${TaskContract.Tasks._UID}=?", arrayOf("filter-uid-1"))
             assertEquals(1, filteredCount)
         } finally {
             taskList.delete()

--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.tasks
@@ -14,9 +12,11 @@ import at.bitfire.ical4android.DmfsStyleProvidersTaskTest
 import at.bitfire.ical4android.DmfsTask
 import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.TaskProvider
+import junit.framework.Assert.assertTrue
+import junit.framework.TestCase.assertEquals
 import net.fortuna.ical4j.model.property.RelatedTo
 import org.dmfs.tasks.contract.TaskContract
-import org.junit.Assert
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
@@ -34,11 +34,71 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
 
         val dmfsTaskListProvider = DmfsTaskListProvider(testAccount, provider.client, providerName)
         val id = dmfsTaskListProvider.createTaskList(info)
-        Assert.assertNotNull(id)
+        assertNotNull(id)
 
         dmfsTaskListProvider.createTaskList(info)
 
         return dmfsTaskListProvider.getTaskList(id)!!
+    }
+
+    @Test
+    fun testCountTasks_empty() {
+        val taskList = createTaskList()
+        try {
+            val count = taskList.countTasks(null, null)
+            assertEquals(0, count)
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
+    fun testCountTasks_withFilter() {
+        val taskList = createTaskList()
+        try {
+            // Add tasks with different UIDs
+            val task1 = Task().apply {
+                uid = "filter-uid-1"
+                summary = "Filter Test 1"
+            }
+            val task2 = Task().apply {
+                uid = "filter-uid-2"
+                summary = "Filter Test 2"
+            }
+            
+            DmfsTask(taskList, task1, "sync-id-1", null, 0).add()
+            DmfsTask(taskList, task2, "sync-id-2", null, 0).add()
+            
+            // Test counting with UID filter
+            val filteredCount = taskList.countTasks("${TaskContract.Tasks._SYNC_ID}=?", arrayOf("sync-id-1"))
+            assertEquals(1, filteredCount)
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
+    fun testCountTasks_withoutFilter() {
+        val taskList = createTaskList()
+        try {
+            // Add multiple tasks
+            val task1 = Task().apply {
+                uid = "task-1"
+                summary = "Test Task 1"
+            }
+            val task2 = Task().apply {
+                uid = "task-2"
+                summary = "Test Task 2"
+            }
+
+            DmfsTask(taskList, task1, "sync-id-1", null, 0).add()
+            DmfsTask(taskList, task2, "sync-id-2", null, 0).add()
+
+            val count = taskList.countTasks(null, null)
+            assertEquals(2, count)
+        } finally {
+            taskList.delete()
+        }
     }
 
     @Test
@@ -76,25 +136,25 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
             taskList.provider.client.query(taskList.tasksPropertiesUri(), null,
                     "${TaskContract.Properties.TASK_ID}=?", arrayOf(childId.toString()),
                     null, null)!!.use { cursor ->
-                Assert.assertEquals(1, cursor.count)
+                assertEquals(1, cursor.count)
                 cursor.moveToNext()
 
                 val row = ContentValues()
                 DatabaseUtils.cursorRowToContentValues(cursor, row)
 
-                Assert.assertEquals(
+                assertEquals(
                     TaskContract.Property.Relation.CONTENT_ITEM_TYPE,
                     row.getAsString(TaskContract.Properties.MIMETYPE)
                 )
-                Assert.assertEquals(
+                assertEquals(
                     parentId,
                     row.getAsLong(TaskContract.Property.Relation.RELATED_ID)
                 )
-                Assert.assertEquals(
+                assertEquals(
                     parent.uid,
                     row.getAsString(TaskContract.Property.Relation.RELATED_UID)
                 )
-                Assert.assertEquals(
+                assertEquals(
                     TaskContract.Property.Relation.RELTYPE_PARENT,
                     row.getAsInteger(TaskContract.Property.Relation.RELATED_TYPE)
                 )
@@ -106,8 +166,8 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
             // now parent_id should bet set
             taskList.provider.client.query(childContentUri, arrayOf(TaskContract.Tasks.PARENT_ID),
                     null, null, null)!!.use { cursor ->
-                Assert.assertTrue(cursor.moveToNext())
-                Assert.assertEquals(parentId, cursor.getLong(0))
+                assertTrue(cursor.moveToNext())
+                assertEquals(parentId, cursor.getLong(0))
             }
         } finally {
             taskList.delete()

--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -1,5 +1,7 @@
 /*
- * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 package at.bitfire.synctools.storage.tasks

--- a/lib/src/androidTest/kotlin/at/bitfire/vcard4android/AndroidAddressBookTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/vcard4android/AndroidAddressBookTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.vcard4android
@@ -14,8 +12,14 @@ import android.provider.ContactsContract
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import at.bitfire.vcard4android.impl.TestAddressBook
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Test
 
 class AndroidAddressBookTest {
 
@@ -45,8 +49,71 @@ class AndroidAddressBookTest {
 
 
     @Test
-	fun testSettings() {
+    fun testCountContacts_empty() {
 		val addressBook = TestAddressBook(testAddressBookAccount, provider)
+        val count = addressBook.countContacts(null, null)
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun testCountContacts_withContacts() {
+		val addressBook = TestAddressBook(testAddressBookAccount, provider)
+        
+        // Create some test contacts
+        val contact1 = AndroidContact(addressBook, Contact().apply { 
+            displayName = "Test Contact 1"
+        }, null, null)
+        contact1.add()
+        
+        val contact2 = AndroidContact(addressBook, Contact().apply { 
+            displayName = "Test Contact 2"
+        }, null, null)
+        contact2.add()
+        
+        try {
+            val count = addressBook.countContacts(null, null)
+            assertEquals(2, count)
+        } finally {
+            contact1.delete()
+            contact2.delete()
+        }
+    }
+
+    @Test
+    fun testCountContacts_withFilter() {
+		val addressBook = TestAddressBook(testAddressBookAccount, provider)
+        
+        // Create test contacts with different UIDs
+        val contact1 = AndroidContact(addressBook, Contact().apply { 
+            displayName = "Filter Test 1"
+            uid = "test-uid-1"
+        }, null, null)
+        contact1.add()
+        
+        val contact2 = AndroidContact(addressBook, Contact().apply { 
+            displayName = "Filter Test 2"
+            uid = "test-uid-2"
+        }, null, null)
+        contact2.add()
+
+        try {
+            // Test counting with filter
+            val filteredCount = addressBook.countContacts("${AndroidContact.COLUMN_UID}=?", arrayOf("test-uid-1"))
+            assertEquals(1, filteredCount)
+
+            // Test counting with non-matching filter
+            val noMatchCount = addressBook.countContacts("${AndroidContact.COLUMN_UID}=?", arrayOf("non-existent"))
+            assertEquals(0, noMatchCount)
+        } finally {
+            contact1.delete()
+            contact2.delete()
+        }
+    }
+
+
+    @Test
+    fun testSettings() {
+        val addressBook = TestAddressBook(testAddressBookAccount, provider)
 
         var values = ContentValues()
         values.put(ContactsContract.Settings.SHOULD_SYNC, false)

--- a/lib/src/androidTest/kotlin/at/bitfire/vcard4android/AndroidAddressBookTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/vcard4android/AndroidAddressBookTest.kt
@@ -1,5 +1,7 @@
 /*
- * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 package at.bitfire.vcard4android

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar
@@ -111,6 +109,26 @@ class AndroidCalendar(
             batch += CpoBuilder.newInsert(row.uri.asSyncAdapter(account))
                 .withValues(row.values)
                 .withValueBackReference(EventsContract.DATA_ROW_EVENT_ID, eventRowIdx)
+    }
+
+    /**
+     * Counts the number of events in this calendar that match the given selection criteria.
+     *
+     * @param where An optional filter declaring which rows to return.
+     * @param whereArgs Optional arguments for [where].
+     * @return The number of events matching the selection criteria.
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun countEvents(where: String?, whereArgs: Array<String>?): Int {
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithCalendarId(where, whereArgs)
+            client.query(eventsUri, null, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+                return cursor.count
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't count events", e)
+        }
+        return 0
     }
 
     /**

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -1,5 +1,7 @@
 /*
- * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -124,7 +124,8 @@ class AndroidCalendar(
     fun countEvents(where: String?, whereArgs: Array<String>?): Int {
         try {
             val (protectedWhere, protectedWhereArgs) = whereWithCalendarId(where, whereArgs)
-            client.query(eventsUri, null, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+            client.query(eventsUri, arrayOf(Events._ID),
+                protectedWhere, protectedWhereArgs, null)?.use { cursor ->
                 return cursor.count
             }
         } catch (e: RemoteException) {

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -128,6 +128,7 @@ class AndroidCalendar(
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't count events", e)
         }
+        // If the query was invalid, an exception should have been thrown. So this should never be reached:
         return 0
     }
 

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -63,7 +63,8 @@ class DmfsTaskList(
     fun countTasks(where: String? = null, whereArgs: Array<String>? = null): Int {
         try {
             val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
-            client.query(tasksUri(), null, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+            client.query(tasksUri(), arrayOf(TaskContract.Tasks._ID),
+                protectedWhere, protectedWhereArgs, null)?.use { cursor ->
                 return cursor.count
             }
         } catch (e: RemoteException) {

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.tasks
@@ -51,6 +49,27 @@ class DmfsTaskList(
 
 
     // CRUD DmfsTask
+
+    /**
+     * Counts the number of tasks in this task list that match the given selection criteria.
+     *
+     * @param where An optional filter declaring which rows to return.
+     * @param whereArgs Optional arguments for [where].
+     * @return The number of tasks matching the selection criteria.
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun countTasks(where: String? = null, whereArgs: Array<String>? = null): Int {
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
+            client.query(tasksUri(), null, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+                return cursor.count
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't count ${providerName.authority} tasks", e)
+        }
+        // If the query was invalid, an exception should have been thrown. So this should never be reached:
+        return 0
+    }
 
     /**
      * Queries tasks from this task list. Adds a WHERE clause that restricts the

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -1,5 +1,7 @@
 /*
- * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 package at.bitfire.synctools.storage.tasks

--- a/lib/src/main/kotlin/at/bitfire/vcard4android/AndroidAddressBook.kt
+++ b/lib/src/main/kotlin/at/bitfire/vcard4android/AndroidAddressBook.kt
@@ -1,5 +1,7 @@
 /*
- * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 package at.bitfire.vcard4android

--- a/lib/src/main/kotlin/at/bitfire/vcard4android/AndroidAddressBook.kt
+++ b/lib/src/main/kotlin/at/bitfire/vcard4android/AndroidAddressBook.kt
@@ -64,7 +64,7 @@ open class AndroidAddressBook<T1: AndroidContact, T2: AndroidGroup>(
      * @return The number of contacts matching the selection criteria.
      */
     fun countContacts(where: String?, whereArgs: Array<String>?): Int {
-        provider!!.query(rawContactsSyncUri(), null,
+        provider!!.query(rawContactsSyncUri(), arrayOf(RawContacts._ID),
             where, whereArgs, null)?.use { cursor ->
             return cursor.count
         }

--- a/lib/src/main/kotlin/at/bitfire/vcard4android/AndroidAddressBook.kt
+++ b/lib/src/main/kotlin/at/bitfire/vcard4android/AndroidAddressBook.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.vcard4android
@@ -56,6 +54,22 @@ open class AndroidAddressBook<T1: AndroidContact, T2: AndroidGroup>(
         get() = ContactsContract.SyncState.get(provider, addressBookAccount)
         set(data) = ContactsContract.SyncState.set(provider, addressBookAccount, data)
 
+    /**
+     * Counts the number of contacts in the address book that match the given selection criteria.
+     *
+     * @param where An optional filter declaring which rows to return.
+     * @param whereArgs Optional arguments for [where].
+     * @return The number of contacts matching the selection criteria.
+     */
+    fun countContacts(where: String?, whereArgs: Array<String>?): Int {
+        provider!!.query(rawContactsSyncUri(), null,
+            where, whereArgs, null)?.use { cursor ->
+            return cursor.count
+        }
+        // If the query was invalid, an exception would have been thrown. So this
+        // should never be reached:
+        return 0
+    }
 
     fun queryContacts(where: String?, whereArgs: Array<String>?): List<T1> {
         val contacts = LinkedList<T1>()

--- a/lib/src/main/kotlin/at/bitfire/vcard4android/AndroidAddressBook.kt
+++ b/lib/src/main/kotlin/at/bitfire/vcard4android/AndroidAddressBook.kt
@@ -66,8 +66,7 @@ open class AndroidAddressBook<T1: AndroidContact, T2: AndroidGroup>(
             where, whereArgs, null)?.use { cursor ->
             return cursor.count
         }
-        // If the query was invalid, an exception would have been thrown. So this
-        // should never be reached:
+        // If the query was invalid, an exception should have been thrown. So this should never be reached:
         return 0
     }
 


### PR DESCRIPTION
Add `countTasks` method to `DmfsTaskList`, `countEvents` method to `AndroidCalendar`, and `countContacts` method to `AndroidAddressBook` with accompanying tests.

Prerequisite for https://github.com/bitfireAT/davx5-ose/pull/2124