### PR TITLE
[ical4j 4.x] Avoid `UnsupportedTemporalTypeException` in `ICalendar.vAlarmToMin()`

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/ical4android/ICalendar.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/ICalendar.kt
@@ -11,6 +11,7 @@ import at.bitfire.synctools.BuildConfig
 import at.bitfire.synctools.exception.InvalidICalendarException
 import at.bitfire.synctools.icalendar.ICalendarParser
 import at.bitfire.synctools.icalendar.validation.ICalPreprocessor
+import at.bitfire.synctools.util.AndroidTimeUtils.toInstant
 import net.fortuna.ical4j.data.CalendarBuilder
 import net.fortuna.ical4j.data.ParserException
 import net.fortuna.ical4j.model.Calendar
@@ -28,6 +29,7 @@ import net.fortuna.ical4j.validate.ValidationException
 import java.io.Reader
 import java.io.StringReader
 import java.time.Duration
+import java.time.Instant
 import java.time.Period
 import java.time.temporal.Temporal
 import java.util.LinkedList
@@ -191,8 +193,8 @@ open class ICalendar {
             var related: Related = trigger.getParameter<Related>(Parameter.RELATED).getOrNull() ?: Related.START
 
             // event/task start/end time
-            val start: Temporal? = refStart?.date
-            var end: Temporal? = refEnd?.date
+            val start = refStart?.date?.toInstant()
+            var end = refEnd?.date?.toInstant()
 
             // event/task end time
             if (end == null && start != null)

--- a/lib/src/test/kotlin/at/bitfire/ical4android/ICalendarTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/ical4android/ICalendarTest.kt
@@ -6,6 +6,8 @@
 
 package at.bitfire.ical4android
 
+import at.bitfire.dateTimeValue
+import at.bitfire.dateValue
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.Property.TRIGGER
 import net.fortuna.ical4j.model.component.VAlarm
@@ -22,6 +24,7 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import java.io.StringReader
 import java.time.Period
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.Temporal
 import kotlin.jvm.optionals.getOrNull
@@ -233,6 +236,78 @@ class ICalendarTest {
         assertEquals(1, min)
 	}
 
+	@Test
+	fun `vAlarmToMin with trigger duration, DtStart is DATE, Duration is java_time_Duration`() {
+		val alarm = VAlarm(Duration("-PT5M").duration)
+		val dtStart = DtStart(dateValue("20260407"))
+		val duration = Duration("PT1H")
+
+		val (ref, min) = ICalendar.vAlarmToMin(
+			alarm = alarm,
+			refStart = dtStart,
+			refEnd = null,
+			refDuration = duration,
+			allowRelEnd = true
+		)!!
+
+		assertEquals(Related.START, ref)
+		assertEquals(5, min)
+	}
+
+	@Test
+	fun `vAlarmToMin with trigger duration, DtStart is DATE, Duration is java_time_Period`() {
+		val alarm = VAlarm(Duration("-PT5M").duration)
+		val dtStart = DtStart(dateValue("20260407"))
+		val duration = Duration("P1D")
+
+		val (ref, min) = ICalendar.vAlarmToMin(
+			alarm = alarm,
+			refStart = dtStart,
+			refEnd = null,
+			refDuration = duration,
+			allowRelEnd = true
+		)!!
+
+		assertEquals(Related.START, ref)
+		assertEquals(5, min)
+	}
+
+	@Test
+	fun `vAlarmToMin with trigger duration and Related=END, DtStart and DtEnd are DATE, allowRelEnd=false`() {
+		val alarm = VAlarm(Duration("-PT5M").duration).apply {
+			getRequiredProperty<Trigger>(TRIGGER).add<Trigger>(Related.END)
+		}
+		val dtStart = DtStart(dateValue("20260407"))
+		val dtEnd = DtStart(dateValue("20260408"))
+
+		val (ref, min) = ICalendar.vAlarmToMin(
+			alarm = alarm,
+			refStart = dtStart,
+			refEnd = dtEnd,
+			refDuration = null,
+			allowRelEnd = false
+		)!!
+
+		assertEquals(Related.START, ref)
+		assertEquals(-(24 * 60 - 5), min)
+	}
+
+	@Test
+	fun `vAlarmToMin with DATE-TIME trigger, DtStart is DATE`() {
+		val alarm = VAlarm(dateTimeValue("20260406T120000", ZoneOffset.UTC).toInstant())
+		val dtStart = DtStart(dateValue("20260407"))
+
+		val (ref, min) = ICalendar.vAlarmToMin(
+			alarm = alarm,
+			refStart = dtStart,
+			refEnd = null,
+			refDuration = null,
+			allowRelEnd = true
+		)!!
+
+		assertEquals(Related.START, ref)
+		assertEquals(12 * 60, min)
+	}
 
 	// TODO Note: can we use the following now when we have ical4j 4.x?
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
@@ -42,6 +42,7 @@ import java.time.ZonedDateTime
 import java.time.chrono.JapaneseDate
 import java.time.format.DateTimeParseException
 import java.time.temporal.Temporal
+import java.time.temporal.UnsupportedTemporalTypeException
 import java.time.zone.ZoneRulesException
 import java.util.Optional
 
@@ -298,8 +299,8 @@ class AndroidTimeUtilsTest {
             JapaneseDate.now().toTimestamp()
 
             fail("Expected exception")
-        } catch (e: IllegalStateException) {
-            assertEquals("Unsupported Temporal type: java.time.chrono.JapaneseDate", e.message)
+        } catch (e: UnsupportedTemporalTypeException) {
+            assertEquals("Can't convert java.time.chrono.JapaneseDate to Instant", e.message)
         }
     }
 
@@ -347,7 +348,7 @@ class AndroidTimeUtilsTest {
 
             fail("Expected exception")
         } catch (e: IllegalArgumentException) {
-            assertEquals("Non-floating date-time must be a ZonedDateTime", e.message)
+            assertEquals("date-time which is neither floating nor UTC must be a ZonedDateTime", e.message)
         }
     }
 


### PR DESCRIPTION
- Fix two test failures introduced in #310.
- Avoid throwing `UnsupportedTemporalTypeException` in `ICalendar.vAlarmToMin()` by converting the start and end times to `Instant` before doing any calculations.