### PR TITLE
Move AndroidTimeZonesTest and improve logging

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/icalendar/AndroidTimeZonesTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/icalendar/AndroidTimeZonesTest.kt
@@ -4,31 +4,30 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-package at.bitfire.ical4android
+package at.bitfire.synctools.icalendar
 
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
-import org.junit.Assert
-import org.junit.Assert.assertNotNull
-import org.junit.Ignore
 import org.junit.Test
 import java.time.ZoneId
 import java.time.format.TextStyle
 import java.util.Locale
+import java.util.logging.Logger
 
 class AndroidTimeZonesTest {
 
+    private val logger
+        get() = Logger.getLogger(javaClass.name)
+
     @Test
-    fun testLoadSystemTimezones() {
+    fun testAndroidTimeZonesAvailableInIcal4j() {
         val tzRegistry = TimeZoneRegistryFactory.getInstance().createRegistry()
         for (id in ZoneId.getAvailableZoneIds()) {
             val name = ZoneId.of(id).getDisplayName(TextStyle.FULL, Locale.US)
-            val info = try {
-                tzRegistry.getTimeZone(id)
-            } catch(e: Exception) {
-                Assert.fail("Invalid system timezone $name ($id)")
-            }
+            val info = tzRegistry.getTimeZone(id)
             if (info == null)
-                assertNotNull("ical4j can't load system timezone $name ($id)", info)
+                logger.warning("Android timezone $id ($name) is not available in the ical4j " +
+                        "timezone database. When a local event is created with $id, it won't have a " +
+                        "VTIMEZONE when uploaded.")
         }
     }
 


### PR DESCRIPTION
Move `AndroidTimeZonesTest` to the `synctools.icalendar` package and enhance timezone test logging for better debugging.