### PR TITLE
Specify `RECURRENCE-ID` in same timezone as main event `DTSTART`

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/OriginalInstanceTimeHandler.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/OriginalInstanceTimeHandler.kt
@@ -15,6 +15,7 @@ import net.fortuna.ical4j.model.property.RecurrenceId
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
 class OriginalInstanceTimeHandler: AndroidEventFieldHandler {
@@ -25,23 +26,25 @@ class OriginalInstanceTimeHandler: AndroidEventFieldHandler {
             return
 
         val values = from.entityValues
-
-        val eventTimezone = DatePropertyTzMapper.systemTzId(values.getAsString(Events.EVENT_TIMEZONE))
-        val zoneId = if (eventTimezone != null) {
-            ZoneId.of(eventTimezone)
-        } else {
-            ZoneId.systemDefault()
-        }
-
         values.getAsLong(Events.ORIGINAL_INSTANCE_TIME)?.let { originalInstanceTime ->
             val originalAllDay = (values.getAsInteger(Events.ORIGINAL_ALL_DAY) ?: 0) != 0
             val instant = Instant.ofEpochMilli(originalInstanceTime)
             to += if (originalAllDay) {
-                RecurrenceId(LocalDate.ofInstant(instant, zoneId))
+                RecurrenceId(LocalDate.ofInstant(instant, ZoneOffset.UTC))
             } else {
-                // get DTSTART time zone
+                val zoneId = getMainEventZoneId(main)
                 RecurrenceId(ZonedDateTime.ofInstant(instant, zoneId))
             }
+        }
+    }
+
+    private fun getMainEventZoneId(main: Entity): ZoneId? {
+        val mainTzId = main.entityValues.getAsString(Events.EVENT_TIMEZONE)
+        val mainTimezone = DatePropertyTzMapper.systemTzId(mainTzId)
+        return if (mainTimezone != null) {
+            ZoneId.of(mainTimezone)
+        } else {
+            ZoneId.systemDefault()
         }
     }
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/AndroidEventHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/AndroidEventHandlerTest.kt
@@ -77,7 +77,7 @@ class AndroidEventHandlerTest {
         assertEquals(DtStart(dateTimeValue("20200706T193000", tzVienna)), main.dtStart<ZonedDateTime>())
         assertEquals("FREQ=DAILY;COUNT=10", main.getProperty<RRule<Temporal>>(Property.RRULE).getOrNull()?.value)
         val exception = result.exceptions.first()
-        assertEquals(RecurrenceId(dateTimeValue("20200708T013000", tzShanghai)), exception.recurrenceId)
+        assertEquals(RecurrenceId(dateTimeValue("20200707T193000", tzVienna)), exception.recurrenceId)
         assertEquals(DtStart(dateTimeValue("20200706T203000", tzShanghai)), exception.dtStart<ZonedDateTime>())
         assertEquals("Event moved to one hour later", exception.summary.value)
     }
@@ -140,7 +140,7 @@ class AndroidEventHandlerTest {
         assertEquals(DtStart(dateTimeValue("20200706T193000", tzVienna)), main.dtStart<ZonedDateTime>())
         assertEquals("FREQ=DAILY;COUNT=10", main.getProperty<RRule<*>>(Property.RRULE).getOrNull()?.value)
         assertEquals(
-            dateTimeValue("20200708T013000", tzShanghai),
+            dateTimeValue("20200707T193000", tzVienna),
             main.getProperty<ExDate<*>>(Property.EXDATE)?.getOrNull()?.dates?.first()
         )
         assertTrue(result.exceptions.isEmpty())

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OriginalInstanceTimeHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OriginalInstanceTimeHandlerTest.kt
@@ -27,34 +27,79 @@ import java.time.ZonedDateTime
 class OriginalInstanceTimeHandlerTest {
 
     @get:Rule
-    val tzRule = DefaultTimezoneRule("Europe/Berlin")
+    val tzRule = DefaultTimezoneRule("Pacific/Auckland")
 
     private val tzVienna = ZoneId.of("Europe/Vienna")
+    private val tzHonolulu = ZoneId.of("Pacific/Honolulu")
 
     private val handler = OriginalInstanceTimeHandler()
 
     @Test
     fun `Original event is all-day`() {
         val result = VEvent()
-        val entity = Entity(contentValuesOf(
+        val from = Entity(contentValuesOf(
             Events.ORIGINAL_INSTANCE_TIME to 1594080000000L,
             Events.ORIGINAL_ALL_DAY to 1
         ))
-        handler.process(entity, Entity(ContentValues()), result)
+        val main = Entity(ContentValues())
+
+        handler.process(from, main, result)
+
         assertEquals(RecurrenceId(LocalDate.of(2020, 7, 7)), result.recurrenceId)
     }
 
     @Test
     fun `Original event is not all-day`() {
         val result = VEvent()
-        val entity = Entity(contentValuesOf(
+        val from = Entity(contentValuesOf(
             Events.ORIGINAL_INSTANCE_TIME to 1758550428000L,
             Events.ORIGINAL_ALL_DAY to 0,
             Events.EVENT_TIMEZONE to tzVienna.id
         ))
-        handler.process(entity, Entity(ContentValues()), result)
+        val main = Entity(contentValuesOf(
+            Events.EVENT_TIMEZONE to tzVienna.id
+        ))
+
+        handler.process(from, main, result)
+
         val viennaDateTime = ZonedDateTime.of(2025, 9, 22, 16, 13, 48, 0, tzVienna)
         assertEquals(RecurrenceId(viennaDateTime), result.recurrenceId)
+    }
+
+    @Test
+    fun `Original event is using different time zone`() {
+        val result = VEvent()
+        val from = Entity(contentValuesOf(
+            Events.ORIGINAL_INSTANCE_TIME to 1758550428000L,
+            Events.ORIGINAL_ALL_DAY to 0,
+            Events.EVENT_TIMEZONE to tzHonolulu.id
+        ))
+        val main = Entity(contentValuesOf(
+            Events.EVENT_TIMEZONE to tzVienna.id
+        ))
+
+        handler.process(from, main, result)
+
+        val viennaDateTime = ZonedDateTime.of(2025, 9, 22, 16, 13, 48, 0, tzVienna)
+        assertEquals(RecurrenceId(viennaDateTime), result.recurrenceId)
+    }
+
+    @Test
+    fun `Original event is missing time zone`() {
+        val result = VEvent()
+        val from = Entity(contentValuesOf(
+            Events.ORIGINAL_INSTANCE_TIME to 1758550428000L,
+            Events.ORIGINAL_ALL_DAY to 0,
+            Events.EVENT_TIMEZONE to tzHonolulu.id
+        ))
+        val main = Entity(contentValuesOf(
+            Events.EVENT_TIMEZONE to null
+        ))
+
+        handler.process(from, main, result)
+
+        val defaultTzDateTime = ZonedDateTime.of(2025, 9, 23, 2, 13, 48, 0, tzRule.defaultZoneId)
+        assertEquals(RecurrenceId(defaultTzDateTime), result.recurrenceId)
     }
 
 }


### PR DESCRIPTION
Use the timezone of the main event in `RECURRENCE-ID` of the exception even when the exception itself is using a different timezone for `DTSTART`.