### PR TITLE
Fix ORGANIZER handling for exception events

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/OrganizerHandler.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/OrganizerHandler.kt
@@ -7,7 +7,7 @@
 package at.bitfire.synctools.mapping.calendar.handler
 
 import android.content.Entity
-import android.provider.CalendarContract.Attendees
+import android.provider.CalendarContract
 import android.provider.CalendarContract.Events
 import at.bitfire.synctools.icalendar.plusAssign
 import net.fortuna.ical4j.model.component.VEvent
@@ -28,7 +28,7 @@ class OrganizerHandler: AndroidEventFieldHandler {
         val mainValues = main.entityValues
 
         // ORGANIZER must only be set for group-scheduled events (= events with attendees)
-        val hasAttendees = from.subValues.any { it.uri == Attendees.CONTENT_URI }
+        val hasAttendees = hasAttendees(from) || hasAttendees(main)
         if (hasAttendees && mainValues.containsKey(Events.ORGANIZER))
             try {
                 to += Organizer(URI("mailto", mainValues.getAsString(Events.ORGANIZER), null))
@@ -36,5 +36,7 @@ class OrganizerHandler: AndroidEventFieldHandler {
                 logger.log(Level.WARNING, "Error when creating ORGANIZER mailto URI, ignoring", e)
             }
     }
+
+    private fun hasAttendees(event: Entity) = event.subValues.any { it.uri == CalendarContract.Attendees.CONTENT_URI }
 
 }

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OrganizerHandlerTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OrganizerHandlerTest.kt
@@ -24,17 +24,7 @@ class OrganizerHandlerTest {
     private val handler = OrganizerHandler()
 
     @Test
-    fun `No ORGANIZER for non-group-scheduled event`() {
-        val result = VEvent()
-        val entity = Entity(contentValuesOf(
-            Events.ORGANIZER to "organizer@example.com"
-        ))
-        handler.process(entity, entity, result)
-        assertNull(result.organizer)
-    }
-
-    @Test
-    fun `ORGANIZER for group-scheduled event`() {
+    fun `ORGANIZER added to event with attendees`() {
         val result = VEvent()
         val entity = Entity(contentValuesOf(
             Events.ORGANIZER to "organizer@example.com"
@@ -45,6 +35,130 @@ class OrganizerHandlerTest {
         ))
         handler.process(entity, entity, result)
         assertEquals(Organizer("mailto:organizer@example.com"), result.organizer)
+    }
+
+    @Test
+    fun `ORGANIZER must be same in exception without attendees`() {
+        // RFC 6638 3.2.4.2: All the calendar components in a scheduling object resource MUST
+        // contain the same "ORGANIZER" property value when present.
+
+        // This test verifies that when the main event has attendees and ORGANIZER, the exception
+        // must also have the same ORGANIZER, even if the exception has no attendees.
+
+        val mainEntity = Entity(contentValuesOf(
+            Events.ORGANIZER to "organizer@example.com"
+        ))
+        mainEntity.addSubValue(Attendees.CONTENT_URI, contentValuesOf(
+            Attendees.ATTENDEE_EMAIL to "organizer@example.com",
+            Attendees.ATTENDEE_TYPE to Attendees.RELATIONSHIP_ORGANIZER
+        ))
+
+        // Exception has no attendees
+        val exceptionEntity = Entity(contentValuesOf())
+
+        // Process main event
+        val mainVEvent = VEvent()
+        handler.process(mainEntity, mainEntity, mainVEvent)
+        assertEquals(Organizer("mailto:organizer@example.com"), mainVEvent.organizer)
+
+        // Process exception - should still get ORGANIZER from main event
+        val exceptionVEvent = VEvent()
+        handler.process(exceptionEntity, mainEntity, exceptionVEvent)
+        assertEquals(Organizer("mailto:organizer@example.com"), exceptionVEvent.organizer)
+    }
+    @Test
+    fun `No ORGANIZER in exception when main has no attendees`() {
+        // If main event has no attendees, no ORGANIZER should be added
+        val mainEntity = Entity(contentValuesOf(
+            Events.ORGANIZER to "organizer@example.com"
+        ))
+        // No attendees subValues
+
+        val exceptionEntity = Entity(contentValuesOf())
+
+        val mainVEvent = VEvent()
+        handler.process(mainEntity, mainEntity, mainVEvent)
+        assertNull(mainVEvent.organizer)
+
+        val exceptionVEvent = VEvent()
+        handler.process(exceptionEntity, mainEntity, exceptionVEvent)
+        assertNull(exceptionVEvent.organizer)
+    }
+
+    @Test
+    fun `ORGANIZER in exception when exception has attendees but main does not`() {
+        val mainEntity = Entity(contentValuesOf(
+            Events.ORGANIZER to "organizer@example.com"
+        ))
+        val exceptionEntity = Entity(contentValuesOf(
+            Events.ORGANIZER to "organizer@example.com"
+        ))
+        exceptionEntity.addSubValue(Attendees.CONTENT_URI, contentValuesOf(
+            Attendees.ATTENDEE_EMAIL to "organizer@example.com",
+            Attendees.ATTENDEE_TYPE to Attendees.RELATIONSHIP_ORGANIZER
+        ))
+        val mainVEvent = VEvent()
+        handler.process(mainEntity, mainEntity, mainVEvent)
+        assertNull(mainVEvent.organizer)
+
+        val exceptionVEvent = VEvent()
+        handler.process(exceptionEntity, mainEntity, exceptionVEvent)
+        assertEquals(Organizer("mailto:organizer@example.com"), exceptionVEvent.organizer)
+    }
+
+    @Test
+    fun `ORGANIZER is preserved when attendees exist`() {
+        val result = VEvent()
+        val entity = Entity(contentValuesOf(
+            Events.ORGANIZER to "organizer@example.com"
+        ))
+        entity.addSubValue(Attendees.CONTENT_URI, contentValuesOf(
+            Attendees.ATTENDEE_EMAIL to "attendee@example.com"
+        ))
+
+        handler.process(entity, entity, result)
+
+        assertEquals(
+            Organizer("mailto:organizer@example.com"),
+            result.organizer
+        )
+    }
+
+    @Test
+    fun `Exception ORGANIZER replaced with main ORGANIZER`() {
+        val mainEntity = Entity(contentValuesOf(
+            Events.ORGANIZER to "organizer@example.com"
+        ))
+        mainEntity.addSubValue(Attendees.CONTENT_URI, contentValuesOf(
+            Attendees.ATTENDEE_EMAIL to "attendee@example.com"
+        ))
+
+        val exceptionEntity = Entity(contentValuesOf(
+            Events.ORGANIZER to "other@example.com"
+        ))
+
+        val exceptionVEvent = VEvent()
+        handler.process(exceptionEntity, mainEntity, exceptionVEvent)
+
+        // override with main
+        assertEquals(
+            Organizer("mailto:organizer@example.com"),
+            exceptionVEvent.organizer
+        )
+    }
+
+    @Test
+    fun `No ORGANIZER anywhere results in no ORGANIZER`() {
+        val mainEntity = Entity(contentValuesOf())
+        val exceptionEntity = Entity(contentValuesOf())
+
+        val mainVEvent = VEvent()
+        handler.process(mainEntity, mainEntity, mainVEvent)
+        assertNull(mainVEvent.organizer)
+
+        val exceptionVEvent = VEvent()
+        handler.process(exceptionEntity, mainEntity, exceptionVEvent)
+        assertNull(exceptionVEvent.organizer)
     }
 
 }


### PR DESCRIPTION
ORGANIZER must be the same value for all participating components - main event and its exceptions.

- In `OrganizerHandler`: Also check whether main event has attendees instead of only checking for exception attendees to decide on whether we should add ORGANIZER to the necessarily group-scheduled event.
- add tests to avoid future regression ensuring ORGANIZER must be same in exception even with/without attendees
