### PR TITLE
Fix sourceSets configuration

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -34,12 +34,9 @@ android {
 
     buildFeatures.buildConfig = true
 
-    sourceSets["main"].apply {
-        kotlin {
-            directories += "${projectDir}/src/main/kotlin"
-        }
-        java {
-            directories += "${rootDir}/opentasks-contract/src/main/java"
+    sourceSets {
+        getByName("main") {
+            java.directories += "${rootDir}/opentasks-contract/src/main/java"
         }
     }
 


### PR DESCRIPTION
Fixes gradle error that was introduced by the previous commit that updated AGP to 9.2.0.