### PR TITLE
Fix R8 build errors after updating to ical4j 4.x

### DIFF
--- a/lib/consumer-rules.pro
+++ b/lib/consumer-rules.pro
@@ -3,11 +3,14 @@
 -keep class net.fortuna.ical4j.** { *; }
 
 # ical4j: don't warn when these are missing
+-dontwarn com.github.benmanes.caffeine.**
 -dontwarn com.github.erosb.jsonsKema.**
 -dontwarn groovy.**
 -dontwarn java.beans.Transient
+-dontwarn java.time.zone.ZoneRulesProvider
 -dontwarn javax.cache.**
 -dontwarn org.codehaus.groovy.**
+-dontwarn org.joda.convert.ToString
 -dontwarn org.jparsec.**
 
 # keep all vCard properties/parameters (used via reflection)


### PR DESCRIPTION
Closes https://github.com/bitfireAT/synctools/issues/335

### Purpose

Fix R8 build errors after updating to ical4j 4.x.  

### Short description

This is assuming we don't want to use the optional caffeine caching library that ical4j uses for timezone caching.

The unresolved references come from 
- `com.github.benmanes.caffeine.**` ical4j - Optional caching library. We have timezone cache configured to use `MapTimeZoneCache` in [ical4j.propterties](https://github.com/bitfireAT/synctools/blob/main/lib/src/main/resources/ical4j.properties) so safe to ignore.
- `org.joda.convert.ToString`: threeten-extra (`@ToString` annotation) - I assume that is safe to ignore.
- `java.time.zone.ZoneRulesProvider`: Runtime support for java.time is provided through desugaring which can lead to a different class path than R8 might expect during static analysis. I think ignoring is safe because DAVx5’s has desugaring enabled.

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

