### PR TITLE
Extract status field builders from DmfsTaskBuilder

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilder.kt
@@ -11,7 +11,12 @@ import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.UnknownProperty
 import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
+import at.bitfire.synctools.mapping.tasks.builder.ClassificationBuilder
+import at.bitfire.synctools.mapping.tasks.builder.CompletedBuilder
 import at.bitfire.synctools.mapping.tasks.builder.DmfsTaskFieldBuilder
+import at.bitfire.synctools.mapping.tasks.builder.PercentCompleteBuilder
+import at.bitfire.synctools.mapping.tasks.builder.PriorityBuilder
+import at.bitfire.synctools.mapping.tasks.builder.StatusBuilder
 import at.bitfire.synctools.mapping.tasks.builder.TitleBuilder
 import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
 import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.COLUMN_ETAG
@@ -34,8 +39,6 @@ import net.fortuna.ical4j.model.property.Action
 import net.fortuna.ical4j.model.property.DtStart
 import net.fortuna.ical4j.model.property.Due
 import net.fortuna.ical4j.model.property.immutable.ImmutableAction
-import net.fortuna.ical4j.model.property.immutable.ImmutableClazz
-import net.fortuna.ical4j.model.property.immutable.ImmutableStatus
 import net.fortuna.ical4j.util.TimeZones
 import org.dmfs.tasks.contract.TaskContract.Properties
 import org.dmfs.tasks.contract.TaskContract.Property.Alarm
@@ -65,7 +68,14 @@ class DmfsTaskBuilder(
 ) {
 
     private val fieldBuilders: Array<DmfsTaskFieldBuilder> = arrayOf(
-        TitleBuilder()
+        // status fields
+        TitleBuilder(),
+        PriorityBuilder(),
+        ClassificationBuilder(),
+        StatusBuilder(),
+        CompletedBuilder(),
+        PercentCompleteBuilder(),
+        // time fields (still inline below)
     )
 
     private val logger
@@ -131,31 +141,6 @@ class DmfsTaskBuilder(
             else
                 logger.warning("Ignoring ORGANIZER without email address (not supported by Android)")
         }
-
-        // Priority, classification
-        builder
-            .withValue(Tasks.PRIORITY, task.priority)
-            .withValue(Tasks.CLASSIFICATION, when (task.classification?.value?.uppercase()) {
-                ImmutableClazz.VALUE_PUBLIC -> Tasks.CLASSIFICATION_PUBLIC
-                ImmutableClazz.VALUE_CONFIDENTIAL -> Tasks.CLASSIFICATION_CONFIDENTIAL
-                null -> Tasks.CLASSIFICATION_DEFAULT
-                else -> Tasks.CLASSIFICATION_PRIVATE    // all unknown classifications MUST be treated as PRIVATE
-            })
-
-        // COMPLETED must always be a DATE-TIME
-        builder
-            .withValue(Tasks.COMPLETED, task.completedAt?.date?.toEpochMilli())
-            .withValue(Tasks.COMPLETED_IS_ALLDAY, 0)
-            .withValue(Tasks.PERCENT_COMPLETE, task.percentComplete)
-
-        // Status
-        val status = when (task.status?.value) {
-            ImmutableStatus.VALUE_IN_PROCESS -> Tasks.STATUS_IN_PROCESS
-            ImmutableStatus.VALUE_COMPLETED  -> Tasks.STATUS_COMPLETED
-            ImmutableStatus.VALUE_CANCELLED  -> Tasks.STATUS_CANCELLED
-            else                             -> Tasks.STATUS_DEFAULT    // == Tasks.STATUS_NEEDS_ACTION
-        }
-        builder.withValue(Tasks.STATUS, status)
 
         // Time related
         val allDay = task.isAllDay()

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilder.kt
@@ -1,0 +1,25 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.tasks.builder
+
+import android.content.Entity
+import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.property.immutable.ImmutableClazz
+import org.dmfs.tasks.contract.TaskContract.Tasks
+
+class ClassificationBuilder : DmfsTaskFieldBuilder {
+
+    override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks.CLASSIFICATION, when (from.classification?.value?.uppercase()) {
+            ImmutableClazz.VALUE_PUBLIC       -> Tasks.CLASSIFICATION_PUBLIC
+            ImmutableClazz.VALUE_CONFIDENTIAL -> Tasks.CLASSIFICATION_CONFIDENTIAL
+            null                              -> Tasks.CLASSIFICATION_DEFAULT
+            else                              -> Tasks.CLASSIFICATION_PRIVATE    // all unknown classifications MUST be treated as PRIVATE
+        })
+    }
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilder.kt
@@ -1,0 +1,21 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.tasks.builder
+
+import android.content.Entity
+import at.bitfire.ical4android.Task
+import org.dmfs.tasks.contract.TaskContract.Tasks
+
+class CompletedBuilder : DmfsTaskFieldBuilder {
+
+    override fun build(from: Task, to: Entity) {
+        // COMPLETED must always be a DATE-TIME
+        to.entityValues.put(Tasks.COMPLETED, from.completedAt?.date?.toEpochMilli())
+        to.entityValues.put(Tasks.COMPLETED_IS_ALLDAY, 0)
+    }
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilder.kt
@@ -1,0 +1,19 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.tasks.builder
+
+import android.content.Entity
+import at.bitfire.ical4android.Task
+import org.dmfs.tasks.contract.TaskContract.Tasks
+
+class PercentCompleteBuilder : DmfsTaskFieldBuilder {
+
+    override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks.PERCENT_COMPLETE, from.percentComplete)
+    }
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilder.kt
@@ -1,0 +1,19 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.tasks.builder
+
+import android.content.Entity
+import at.bitfire.ical4android.Task
+import org.dmfs.tasks.contract.TaskContract.Tasks
+
+class PriorityBuilder : DmfsTaskFieldBuilder {
+
+    override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks.PRIORITY, from.priority)
+    }
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilder.kt
@@ -1,0 +1,25 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.tasks.builder
+
+import android.content.Entity
+import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.property.immutable.ImmutableStatus
+import org.dmfs.tasks.contract.TaskContract.Tasks
+
+class StatusBuilder : DmfsTaskFieldBuilder {
+
+    override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks.STATUS, when (from.status?.value) {
+            ImmutableStatus.VALUE_IN_PROCESS -> Tasks.STATUS_IN_PROCESS
+            ImmutableStatus.VALUE_COMPLETED  -> Tasks.STATUS_COMPLETED
+            ImmutableStatus.VALUE_CANCELLED  -> Tasks.STATUS_CANCELLED
+            else                             -> Tasks.STATUS_DEFAULT    // == Tasks.STATUS_NEEDS_ACTION
+        })
+    }
+
+}

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilderTest.kt
@@ -1,0 +1,86 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.tasks.builder
+
+import android.content.ContentValues
+import android.content.Entity
+import androidx.core.content.contentValuesOf
+import at.bitfire.ical4android.Task
+import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.property.Clazz
+import net.fortuna.ical4j.model.property.immutable.ImmutableClazz
+import org.dmfs.tasks.contract.TaskContract.Tasks
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ClassificationBuilderTest {
+
+    private val builder = ClassificationBuilder()
+
+    @Test
+    fun `No CLASS defaults to DEFAULT`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CLASSIFICATION to Tasks.CLASSIFICATION_DEFAULT
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `CLASS is PUBLIC`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(classification = Clazz(ImmutableClazz.VALUE_PUBLIC)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CLASSIFICATION to Tasks.CLASSIFICATION_PUBLIC
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `CLASS is PRIVATE`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(classification = Clazz(ImmutableClazz.VALUE_PRIVATE)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CLASSIFICATION to Tasks.CLASSIFICATION_PRIVATE
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `CLASS is CONFIDENTIAL`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(classification = Clazz(ImmutableClazz.VALUE_CONFIDENTIAL)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CLASSIFICATION to Tasks.CLASSIFICATION_CONFIDENTIAL
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `Unknown CLASS maps to PRIVATE`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(classification = Clazz("X-CUSTOM")),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CLASSIFICATION to Tasks.CLASSIFICATION_PRIVATE
+        ), result.entityValues)
+    }
+
+}

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilderTest.kt
@@ -1,0 +1,53 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.tasks.builder
+
+import android.content.ContentValues
+import android.content.Entity
+import androidx.core.content.contentValuesOf
+import at.bitfire.ical4android.Task
+import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.property.Completed
+import org.dmfs.tasks.contract.TaskContract.Tasks
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+class CompletedBuilderTest {
+
+    private val builder = CompletedBuilder()
+
+    @Test
+    fun `No COMPLETED`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.COMPLETED to null,
+            Tasks.COMPLETED_IS_ALLDAY to 0
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `COMPLETED is set`() {
+        val instant = Instant.ofEpochMilli(1_000_000L)
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(completedAt = Completed(instant)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.COMPLETED to 1_000_000L,
+            Tasks.COMPLETED_IS_ALLDAY to 0
+        ), result.entityValues)
+    }
+
+}

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilderTest.kt
@@ -1,0 +1,60 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.tasks.builder
+
+import android.content.ContentValues
+import android.content.Entity
+import androidx.core.content.contentValuesOf
+import at.bitfire.ical4android.Task
+import at.bitfire.synctools.test.assertContentValuesEqual
+import org.dmfs.tasks.contract.TaskContract.Tasks
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PercentCompleteBuilderTest {
+
+    private val builder = PercentCompleteBuilder()
+
+    @Test
+    fun `No PERCENT-COMPLETE`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.PERCENT_COMPLETE to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `PERCENT-COMPLETE is 50`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(percentComplete = 50),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.PERCENT_COMPLETE to 50
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `PERCENT-COMPLETE is 100`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(percentComplete = 100),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.PERCENT_COMPLETE to 100
+        ), result.entityValues)
+    }
+
+}

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilderTest.kt
@@ -1,0 +1,48 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.tasks.builder
+
+import android.content.ContentValues
+import android.content.Entity
+import androidx.core.content.contentValuesOf
+import at.bitfire.ical4android.Task
+import at.bitfire.synctools.test.assertContentValuesEqual
+import org.dmfs.tasks.contract.TaskContract.Tasks
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PriorityBuilderTest {
+
+    private val builder = PriorityBuilder()
+
+    @Test
+    fun `No PRIORITY`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.PRIORITY to 0
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `PRIORITY is 5`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(priority = 5),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.PRIORITY to 5
+        ), result.entityValues)
+    }
+
+}

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilderTest.kt
@@ -1,0 +1,86 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.tasks.builder
+
+import android.content.ContentValues
+import android.content.Entity
+import androidx.core.content.contentValuesOf
+import at.bitfire.ical4android.Task
+import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.property.Status
+import net.fortuna.ical4j.model.property.immutable.ImmutableStatus
+import org.dmfs.tasks.contract.TaskContract.Tasks
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StatusBuilderTest {
+
+    private val builder = StatusBuilder()
+
+    @Test
+    fun `No STATUS defaults to STATUS_DEFAULT`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.STATUS to Tasks.STATUS_DEFAULT
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `STATUS is NEEDS-ACTION`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(status = Status(ImmutableStatus.VALUE_NEEDS_ACTION)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.STATUS to Tasks.STATUS_NEEDS_ACTION
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `STATUS is IN-PROCESS`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(status = Status(ImmutableStatus.VALUE_IN_PROCESS)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.STATUS to Tasks.STATUS_IN_PROCESS
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `STATUS is COMPLETED`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(status = Status(ImmutableStatus.VALUE_COMPLETED)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.STATUS to Tasks.STATUS_COMPLETED
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `STATUS is CANCELLED`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(status = Status(ImmutableStatus.VALUE_CANCELLED)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.STATUS to Tasks.STATUS_CANCELLED
+        ), result.entityValues)
+    }
+
+}


### PR DESCRIPTION
Closes #355. Part of #340.

Extract `PriorityBuilder`, `ClassificationBuilder`, `StatusBuilder`, `CompletedBuilder`, and `PercentCompleteBuilder` from the inline code in `DmfsTaskBuilder.buildTask()`.

Each builder has a corresponding unit test.

> [!NOTE]
> This PR is stacked on #359. Review the diff against `340-2-content-builders`.