### PR TITLE
Add `MainItemAndExceptions` to storage layer

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/MainItemAndExceptions.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/MainItemAndExceptions.kt
@@ -1,0 +1,22 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.storage
+
+import android.content.Entity
+
+/**
+ * Represents a set of a local main item (event, task, journal) and associated exceptions that are
+ * stored together.
+ *
+ * It consists of
+ * - a (potentially recurring) main item,
+ * - optional exceptions to this main item (exception instances, only useful if main item is recurring).
+ */
+data class MainItemAndExceptions(
+    val main: Entity,
+    val exceptions: List<Entity>
+)

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/calendar/EventAndExceptions.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/calendar/EventAndExceptions.kt
@@ -6,15 +6,6 @@
 
 package at.bitfire.synctools.storage.calendar
 
-import android.content.Entity
+import at.bitfire.synctools.storage.MainItemAndExceptions
 
-/**
- * Represents a set of a local Android event and associated exception events that are stored together. It consists of
- *
- * - a (potentially recurring) main event,
- * - optional exceptions of this main event (exception instances, only useful if main event is recurring).
- */
-data class EventAndExceptions(
-    val main: Entity,
-    val exceptions: List<Entity>
-)
+typealias EventAndExceptions = MainItemAndExceptions

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxItemAndExceptions.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxItemAndExceptions.kt
@@ -1,0 +1,11 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.storage.jtx
+
+import at.bitfire.synctools.storage.MainItemAndExceptions
+
+typealias JtxItemAndExceptions = MainItemAndExceptions


### PR DESCRIPTION
For now calendars, tasks, and journals don't need specialized data classes to pass data to the storage layer. We're renaming `EventAndExceptions` to `MainItemAndExceptions` and move it to the `storage` package.

The `storage.calendar` package is still using the `EventAndExceptions` name via a typealias. The same is added for `storage.jtx`. This has two advantages:
- This PR stays small.
- Should we later have to add a more specific data class for one storage package, we can easily do that without ending up with a large diff.