### PR TITLE
Move Account management and related utils to synctools

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/synctools/util/AccountManagerExtensions.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/util/AccountManagerExtensions.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.util
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import java.util.logging.Logger
+
+/**
+ * [AccountManager.setUserData] has been found to be unreliable at times. This extension function
+ * checks whether the user data has actually been set and retries up to ten times before failing silently.
+ *
+ * It should only be used to store the reference to the database (like the collection ID that this account represents).
+ * Everything else should be in the DB.
+ */
+fun AccountManager.setAndVerifyUserData(account: Account, key: String, value: String?) {
+    for (i in 1..10) {
+        if (getUserData(account, key) == value)
+        /* already set / success */
+            return
+
+        setUserData(account, key, value)
+
+        // wait a bit because AccountManager access sometimes seems a bit asynchronous
+        Thread.sleep(100)
+    }
+    Logger.getGlobal().warning("AccountManager failed to set $account user data $key := $value")
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/util/AccountManagerExtensions.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/util/AccountManagerExtensions.kt
@@ -1,5 +1,7 @@
 /*
- * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 package at.bitfire.synctools.util
@@ -10,21 +12,22 @@ import java.util.logging.Logger
 
 /**
  * [AccountManager.setUserData] has been found to be unreliable at times. This extension function
- * checks whether the user data has actually been set and retries up to ten times before failing silently.
+ * checks whether the user data has actually been set and retries up to ten times before it gives up,
+ * without throwing an Exception.
  *
- * It should only be used to store the reference to the database (like the collection ID that this account represents).
- * Everything else should be in the DB.
+ * Account user data should only be used to reference an own reliable storage.
  */
 fun AccountManager.setAndVerifyUserData(account: Account, key: String, value: String?) {
     for (i in 1..10) {
         if (getUserData(account, key) == value)
-        /* already set / success */
-            return
+            return  /* already set / success */
 
         setUserData(account, key, value)
 
         // wait a bit because AccountManager access sometimes seems a bit asynchronous
         Thread.sleep(100)
     }
-    Logger.getGlobal().warning("AccountManager failed to set $account user data $key := $value")
+
+    val logger = Logger.getLogger(javaClass.name)
+    logger.warning("AccountManager failed to set $account user data $key := $value")
 }

--- a/lib/src/main/kotlin/at/bitfire/synctools/util/AndroidAccountUtils.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/util/AndroidAccountUtils.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.util
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.Context
+import android.os.Bundle
+
+object AndroidAccountUtils {
+
+    /**
+     * Creates a system account and makes sure the user data are set correctly.
+     *
+     * @param context  operating context
+     * @param account  account to create
+     * @param userData user data to set
+     * @param password password to set
+     *
+     * @return whether the account has been created
+     *
+     * @throws IllegalArgumentException when user data contains non-String values
+     * @throws IllegalStateException if user data can't be set
+     */
+    fun createAccount(context: Context, account: Account, userData: Map<String, String>, password: String? = null): Boolean {
+        val userDataBundle = Bundle(userData.size).apply {
+            for ((key, value) in userData)
+                putString(key, value)
+        }
+
+        // create account
+        val manager = AccountManager.get(context)
+        if (!manager.addAccountExplicitly(account, password, userDataBundle))
+            return false
+
+        // Android seems to lose the initial user data sometimes, so make sure that the values are set
+        for ((key, value) in userData)
+            manager.setAndVerifyUserData(account, key, value)
+
+        return true
+    }
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/util/AndroidAccountUtils.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/util/AndroidAccountUtils.kt
@@ -24,7 +24,7 @@ object AndroidAccountUtils {
      * @throws IllegalArgumentException when user data contains non-String values
      * @throws IllegalStateException if user data can't be set
      */
-    fun createAccount(context: Context, account: Account, userData: Map<String, String>, password: String? = null): Boolean {
+    fun createAccount(context: Context, account: Account, userData: Map<String, String>, password: SensitiveString? = null): Boolean {
         val userDataBundle = Bundle(userData.size).apply {
             for ((key, value) in userData)
                 putString(key, value)
@@ -32,7 +32,7 @@ object AndroidAccountUtils {
 
         // create account
         val manager = AccountManager.get(context)
-        if (!manager.addAccountExplicitly(account, password, userDataBundle))
+        if (!manager.addAccountExplicitly(account, password?.toString(), userDataBundle))
             return false
 
         // Android seems to lose the initial user data sometimes, so make sure that the values are set

--- a/lib/src/main/kotlin/at/bitfire/synctools/util/AndroidAccountUtils.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/util/AndroidAccountUtils.kt
@@ -1,5 +1,7 @@
 /*
- * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 package at.bitfire.synctools.util
@@ -20,9 +22,6 @@ object AndroidAccountUtils {
      * @param password password to set
      *
      * @return whether the account has been created
-     *
-     * @throws IllegalArgumentException when user data contains non-String values
-     * @throws IllegalStateException if user data can't be set
      */
     fun createAccount(context: Context, account: Account, userData: Map<String, String>, password: SensitiveString? = null): Boolean {
         val userDataBundle = Bundle(userData.size).apply {
@@ -32,7 +31,7 @@ object AndroidAccountUtils {
 
         // create account
         val manager = AccountManager.get(context)
-        if (!manager.addAccountExplicitly(account, password?.toString(), userDataBundle))
+        if (!manager.addAccountExplicitly(account, password?.asString(), userDataBundle))
             return false
 
         // Android seems to lose the initial user data sometimes, so make sure that the values are set

--- a/lib/src/main/kotlin/at/bitfire/synctools/util/SensitiveString.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/util/SensitiveString.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.util
+
+/**
+ * Wrapper for passwords and other sensitive strings so that they're not directly [String]s,
+ * so that they're less likely to be used in clear-text unintentionally, like being printed in logs
+ * by [Any.toString].
+ *
+ * This class does not address the issue that clear-text passwords are stored in memory. This problem
+ * could only be reduced if we would consequently store and process only encrypted passwords, with the
+ * exception of some "providePassword" method that provides the clear-text password for a lambda function as
+ * [CharArray] and wipes out the array values after usage.
+ *
+ * See also:
+ *
+ * - https://stackoverflow.com/a/8889285
+ * - https://javaee.github.io/security-api/apidocs/javax/security/enterprise/credential/Password.html and
+ *   https://javaee.github.io/security-api/apidocs/javax/security/enterprise/credential/UsernamePasswordCredential.html
+ */
+class SensitiveString private constructor(
+    private val data: String
+) {
+
+    /**
+     * Returns the sensitive string as a [CharArray].
+     *
+     * _Be careful when using it (for instance, don't print its content unintentionally)._
+     */
+    fun asCharArray() = data.toCharArray()
+
+    /**
+     * Returns the sensitive string as an immutable [String].
+     *
+     * _Be careful when using it (for instance, don't print it unintentionally)._
+     */
+    fun asString() = data
+
+
+    // make comparable by data
+
+    override fun equals(other: Any?) =
+        if (other is SensitiveString)
+            data == other.data
+        else
+            false
+
+    override fun hashCode() = data.hashCode()
+
+
+    /**
+     * Overrides [toString] so that it doesn't expose the clear-text string (password).
+     */
+    override fun toString() = "*****"
+
+
+    companion object {
+
+        fun CharArray.toSensitiveString() =
+            SensitiveString(this.concatToString())
+
+        fun CharSequence.toSensitiveString() =
+            SensitiveString(this.toString())
+
+    }
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/util/SensitiveString.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/util/SensitiveString.kt
@@ -10,8 +10,8 @@ package at.bitfire.synctools.util
  * by [Any.toString].
  *
  * This class does not address the issue that clear-text passwords are stored in memory. This problem
- * could only be reduced if we would consequently store and process only encrypted passwords, with the
- * exception of some "providePassword" method that provides the clear-text password for a lambda function as
+ * could only be reduced if we would consequently store and process only encrypted passwords, except
+ * some "providePassword" method that provides the clear-text password for a lambda function as
  * [CharArray] and wipes out the array values after usage.
  *
  * See also:
@@ -20,7 +20,8 @@ package at.bitfire.synctools.util
  * - https://javaee.github.io/security-api/apidocs/javax/security/enterprise/credential/Password.html and
  *   https://javaee.github.io/security-api/apidocs/javax/security/enterprise/credential/UsernamePasswordCredential.html
  */
-class SensitiveString private constructor(
+@JvmInline
+value class SensitiveString private constructor(
     private val data: String
 ) {
 
@@ -37,18 +38,6 @@ class SensitiveString private constructor(
      * _Be careful when using it (for instance, don't print it unintentionally)._
      */
     fun asString() = data
-
-
-    // make comparable by data
-
-    override fun equals(other: Any?) =
-        if (other is SensitiveString)
-            data == other.data
-        else
-            false
-
-    override fun hashCode() = data.hashCode()
-
 
     /**
      * Overrides [toString] so that it doesn't expose the clear-text string (password).

--- a/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidAccountUtilsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidAccountUtilsTest.kt
@@ -1,5 +1,7 @@
 /*
- * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 package at.bitfire.synctools.util
@@ -7,7 +9,9 @@ package at.bitfire.synctools.util
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.Context
-import org.junit.Assert
+import at.bitfire.synctools.util.SensitiveString.Companion.toSensitiveString
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -25,16 +29,17 @@ class AndroidAccountUtilsTest {
             "string" to "abc/\"-"
         )
 
-        val account = Account(javaClass.name, "test")
+        val account = Account("testCreateAccount", javaClass.name)
         val manager = AccountManager.get(context)
         try {
-            Assert.assertTrue(AndroidAccountUtils.createAccount(context, account, userData))
+            assertTrue(AndroidAccountUtils.createAccount(context, account, userData, "secret".toSensitiveString()))
 
             // validate user data
-            Assert.assertEquals("1", manager.getUserData(account, "int"))
-            Assert.assertEquals("abc/\"-", manager.getUserData(account, "string"))
+            assertEquals("1", manager.getUserData(account, "int"))
+            assertEquals("abc/\"-", manager.getUserData(account, "string"))
+            assertEquals("secret", manager.getPassword(account))
         } finally {
-            Assert.assertTrue(manager.removeAccountExplicitly(account))
+            assertTrue(manager.removeAccountExplicitly(account))
         }
     }
 

--- a/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidAccountUtilsTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/util/AndroidAccountUtilsTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.util
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.Context
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidAccountUtilsTest {
+
+    val context: Context = RuntimeEnvironment.getApplication()
+
+    @Test
+    fun testCreateAccount() {
+        val userData = mapOf(
+            "int" to "1",
+            "string" to "abc/\"-"
+        )
+
+        val account = Account(javaClass.name, "test")
+        val manager = AccountManager.get(context)
+        try {
+            Assert.assertTrue(AndroidAccountUtils.createAccount(context, account, userData))
+
+            // validate user data
+            Assert.assertEquals("1", manager.getUserData(account, "int"))
+            Assert.assertEquals("abc/\"-", manager.getUserData(account, "string"))
+        } finally {
+            Assert.assertTrue(manager.removeAccountExplicitly(account))
+        }
+    }
+
+}

--- a/lib/src/test/kotlin/at/bitfire/synctools/util/SensitiveStringTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/util/SensitiveStringTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.util
+
+import at.bitfire.synctools.util.SensitiveString.Companion.toSensitiveString
+import org.junit.Assert
+import org.junit.Test
+
+class SensitiveStringTest {
+
+    private data class UsernameAndPassword(
+        val username: String,
+        val password: SensitiveString
+    )
+
+    @Test
+    fun `equals (other object)`() {
+        val password = "some-password".toSensitiveString()
+        Assert.assertFalse(password == Any())
+    }
+
+    @Test
+    fun `equals (other password)`() {
+        val password = "some-password".toSensitiveString()
+        Assert.assertFalse(password == "other-password".toSensitiveString())
+    }
+
+    @Test
+    fun `equals (same password)`() {
+        val password = "some-password".toSensitiveString()
+        Assert.assertTrue(password == "some-password".toSensitiveString())
+    }
+
+    @Test
+    fun `toString in data class`() {
+        val credentials = UsernameAndPassword(
+            "some-user",
+            "some-password".toSensitiveString()
+        )
+
+        val logMessage = "Credentials: $credentials"
+        Assert.assertEquals("Credentials: UsernameAndPassword(username=some-user, password=*****)", logMessage)
+    }
+
+}


### PR DESCRIPTION
Move from DAVx5 to synctools:

- Account management utils
  - change user data from `Bundle` to `Map<String,String>` since only String values and keys were supported anyway (obsoletes exceptions on non-String values)
- `SensitiveString` (1:1 copy)

DAVx5 counterpart that depends on this PR: https://github.com/bitfireAT/davx5-ose/pull/2218