### PR TITLE
`JtxCollection`: Add CRUD operations for `JtxICalObject`

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
@@ -177,7 +177,7 @@ class JtxCollectionTest {
 
     @Test
     fun testFindJtxObject_found() {
-        val entity = sampleEntity()
+        val entity = sampleEntity("Test Object")
         collection.addJtxObject(entity)
 
         val result = collection.findJtxObject(

--- a/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
@@ -1,0 +1,433 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.storage.jtx
+
+import android.accounts.Account
+import android.content.ContentProviderClient
+import android.content.ContentUris
+import android.content.ContentValues
+import android.content.Entity
+import androidx.core.content.contentValuesOf
+import androidx.test.platform.app.InstrumentationRegistry
+import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.BatchOperation
+import at.bitfire.synctools.storage.JtxBatchOperation
+import at.bitfire.synctools.test.GrantPermissionOrSkipRule
+import at.bitfire.synctools.test.assertEntitiesEqual
+import at.techbee.jtx.JtxContract
+import at.techbee.jtx.JtxContract.JtxICalObject.Component
+import at.techbee.jtx.JtxContract.asSyncAdapter
+import org.junit.After
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Test
+
+class JtxCollectionTest {
+
+    companion object {
+
+        @JvmField
+        @ClassRule
+        val permissionRule = GrantPermissionOrSkipRule(TaskProvider.PERMISSIONS_JTX.toSet())
+
+        private val testAccount = Account(
+            JtxCollectionTest::class.java.name,
+            JtxContract.JtxCollection.TEST_ACCOUNT_TYPE
+        )
+
+        private lateinit var client: ContentProviderClient
+        private lateinit var provider: JtxCollectionProvider
+        private lateinit var collection: JtxCollection
+
+        @BeforeClass
+        @JvmStatic
+        fun setUpClass() {
+            val context = InstrumentationRegistry.getInstrumentation().targetContext
+            client = context.contentResolver.acquireContentProviderClient(JtxContract.AUTHORITY)!!
+            provider = JtxCollectionProvider(testAccount, client)
+            collection = provider.createAndGetCollection(contentValuesOf(
+                JtxContract.JtxCollection.URL to "https://example.com/test",
+                JtxContract.JtxCollection.DISPLAYNAME to "Test Collection",
+                JtxContract.JtxCollection.SUPPORTSVTODO to true,
+                JtxContract.JtxCollection.SUPPORTSVJOURNAL to true
+            ))
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDownClass() {
+            collection.delete()
+            client.close()
+        }
+
+    }
+
+    @After
+    fun cleanUp() {
+        collection.deleteAllJtxObjects()
+    }
+
+
+    // test helpers
+
+    private fun sampleEntity(summary: String = "Test Object") = Entity(contentValuesOf(
+        JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID to collection.id,
+        JtxContract.JtxICalObject.COMPONENT to Component.VTODO.name,
+        JtxContract.JtxICalObject.SUMMARY to summary
+    ))
+
+    private fun sampleEntityWithSubValues(summary: String = "Test Object") =
+        sampleEntity(summary).apply {
+            addSubValue(JtxContract.JtxCategory.CONTENT_URI, contentValuesOf(
+                JtxContract.JtxCategory.TEXT to "sample-category"
+            ))
+        }
+
+
+    // CRUD JtxObject
+
+    @Test
+    fun testAddJtxObject_and_GetJtxObject() {
+        val entity = sampleEntityWithSubValues()
+        val id = collection.addJtxObject(entity)
+
+        val result = collection.getJtxObject(id)!!
+        assertEntitiesEqual(entity, result, onlyFieldsInExpected = true)
+    }
+
+    @Test
+    fun testAddJtxObject_toBatch_AsSecondOperation() {
+        val batch = JtxBatchOperation(client)
+
+        // first operation: no-op
+        batch += BatchOperation.CpoBuilder
+            .newUpdate(collection.jtxObjectsUri)
+            .withValue(JtxContract.JtxICalObject.UID, "won't happen")
+            .withSelection(
+                "${JtxContract.JtxICalObject.UID}=?",
+                arrayOf("testAddObject_toBatch_AsSecondOperation")
+            )
+
+        // second operation (object row index > 0)
+        val entity = sampleEntityWithSubValues()
+        val idx = batch.nextBackrefIdx()
+        collection.addJtxObject(entity, batch)
+
+        batch.commit()
+        val id = ContentUris.parseId(batch.getResult(idx)!!.uri!!)
+
+        val result = collection.getJtxObject(id)!!
+        assertEntitiesEqual(entity, result, onlyFieldsInExpected = true)
+    }
+
+    @Test
+    fun testCountJtxObjects_empty() {
+        assertEquals(0, collection.countJtxObjects(null, null))
+    }
+
+    @Test
+    fun testCountJtxObjects_withJtxObjects() {
+        collection.addJtxObject(sampleEntity("Object 1"))
+        collection.addJtxObject(sampleEntity("Object 2"))
+        assertEquals(2, collection.countJtxObjects(null, null))
+    }
+
+    @Test
+    fun testCountJtxObjects_filterMatch() {
+        collection.addJtxObject(sampleEntity("Object A"))
+        collection.addJtxObject(sampleEntity("Object B"))
+        assertEquals(
+            1,
+            collection.countJtxObjects(
+                "${JtxContract.JtxICalObject.SUMMARY}=?",
+                arrayOf("Object A")
+            )
+        )
+    }
+
+    @Test
+    fun testCountJtxObjects_filterNoMatch() {
+        collection.addJtxObject(sampleEntity("Object A"))
+        assertEquals(
+            0,
+            collection.countJtxObjects(
+                "${JtxContract.JtxICalObject.SUMMARY}=?",
+                arrayOf("Does Not Exist")
+            )
+        )
+    }
+
+    @Test
+    fun testFindJtxObject_notFound() {
+        assertNull(
+            collection.findJtxObject(
+                "${JtxContract.JtxICalObject.SUMMARY}=?",
+                arrayOf("Does Not Exist")
+            )
+        )
+    }
+
+    @Test
+    fun testFindJtxObject_found() {
+        val entity = sampleEntity()
+        collection.addJtxObject(entity)
+
+        val result = collection.findJtxObject(
+            "${JtxContract.JtxICalObject.SUMMARY}=?",
+            arrayOf("Test Object")
+        )
+        assertNotNull(result)
+        assertEntitiesEqual(entity, result!!, onlyFieldsInExpected = true)
+    }
+
+    @Test
+    fun testFindJtxObjects() {
+        collection.addJtxObject(sampleEntity("Object A"))
+        val id2 = collection.addJtxObject(sampleEntity("Object B"))
+        val id3 = collection.addJtxObject(sampleEntity("Object B"))
+
+        val results = collection.findJtxObjects(
+            "${JtxContract.JtxICalObject.SUMMARY}=?",
+            arrayOf("Object B")
+        )
+        assertEquals(2, results.size)
+        assertEquals(
+            setOf(id2, id3),
+            results.map { it.entityValues.getAsLong(JtxContract.JtxICalObject.ID) }.toSet()
+        )
+    }
+
+    @Test
+    fun testFindJtxObjectRow() {
+        val id = collection.addJtxObject(sampleEntity("Row Object"))
+
+        val result = collection.findJtxObjectRow(
+            arrayOf(JtxContract.JtxICalObject.ID, JtxContract.JtxICalObject.SUMMARY),
+            "${JtxContract.JtxICalObject.SUMMARY}=?",
+            arrayOf("Row Object")
+        )
+        assertNotNull(result)
+        assertEquals(id, result!!.getAsLong(JtxContract.JtxICalObject.ID))
+        assertEquals("Row Object", result.getAsString(JtxContract.JtxICalObject.SUMMARY))
+    }
+
+    @Test
+    fun testFindJtxObjectRow_NotExisting() {
+        assertNull(
+            collection.findJtxObjectRow(
+                null,
+                "${JtxContract.JtxICalObject.SUMMARY}=?",
+                arrayOf("Does Not Exist")
+            )
+        )
+    }
+
+    @Test
+    fun testGetJtxObjectRow() {
+        val id = collection.addJtxObject(sampleEntity("Row Object by ID"))
+
+        val result = collection.getJtxObjectRow(id, arrayOf(JtxContract.JtxICalObject.ID, JtxContract.JtxICalObject.SUMMARY))
+        assertNotNull(result)
+        assertEquals(id, result!!.getAsLong(JtxContract.JtxICalObject.ID))
+        assertEquals("Row Object by ID", result.getAsString(JtxContract.JtxICalObject.SUMMARY))
+    }
+
+    @Test
+    fun testGetJtxObjectRow_NotExisting() {
+        assertNull(collection.getJtxObjectRow(Long.MAX_VALUE))
+    }
+
+    @Test
+    fun testIterateJtxObjectRows() {
+        val id1 = collection.addJtxObject(sampleEntity("Object 1"))
+        val id2 = collection.addJtxObject(sampleEntity("Object 2"))
+
+        val result = mutableListOf<ContentValues>()
+        collection.iterateJtxObjectRows(
+            arrayOf(JtxContract.JtxICalObject.ID, JtxContract.JtxICalObject.SUMMARY),
+            null, null
+        ) { row ->
+            result += row
+        }
+
+        assertEquals(
+            setOf(id1, id2),
+            result.map { it.getAsLong(JtxContract.JtxICalObject.ID) }.toSet()
+        )
+        assertEquals(
+            setOf("Object 1", "Object 2"),
+            result.map { it.getAsString(JtxContract.JtxICalObject.SUMMARY) }.toSet()
+        )
+    }
+
+    @Test
+    fun testIterateJtxObjects() {
+        val id1 = collection.addJtxObject(sampleEntityWithSubValues("Object 1"))
+        val id2 = collection.addJtxObject(sampleEntityWithSubValues("Object 2"))
+
+        val result = mutableListOf<Entity>()
+        collection.iterateJtxObjects(null, null) { result += it }
+
+        assertEquals(
+            setOf(id1, id2),
+            result.map { it.entityValues.getAsLong(JtxContract.JtxICalObject.ID) }.toSet()
+        )
+        assertEquals(
+            setOf("Object 1", "Object 2"),
+            result.map { it.entityValues.getAsString(JtxContract.JtxICalObject.SUMMARY) }.toSet()
+        )
+        // each entity should have its sub-rows loaded
+        result.forEach { assertEquals(1, it.subValues.size) }
+    }
+
+    @Test
+    fun testUpdateJtxObjectRow() {
+        val id = collection.addJtxObject(sampleEntity("Original Title"))
+        collection.updateJtxObjectRow(id, contentValuesOf(JtxContract.JtxICalObject.SUMMARY to "Updated Title"))
+        assertEquals("Updated Title", collection.getJtxObject(id)!!.entityValues.getAsString(JtxContract.JtxICalObject.SUMMARY))
+    }
+
+    @Test
+    fun testUpdateJtxObjectRowBatch() {
+        val id = collection.addJtxObject(sampleEntity("Original Title"))
+
+        val batch = JtxBatchOperation(client)
+        collection.updateJtxObjectRow(id, contentValuesOf(JtxContract.JtxICalObject.SUMMARY to "Batch Updated Title"), batch)
+        batch.commit()
+
+        assertEquals("Batch Updated Title", collection.getJtxObject(id)!!.entityValues.getAsString(JtxContract.JtxICalObject.SUMMARY))
+    }
+
+    @Test
+    fun testUpdateJtxObject() {
+        val entity = sampleEntityWithSubValues("Original Title")
+        val id = collection.addJtxObject(entity)
+
+        // build updated entity: new summary, different category
+        val updatedEntity = Entity(ContentValues(entity.entityValues).apply {
+            put(JtxContract.JtxICalObject.SUMMARY, "New Title")
+        }).apply {
+            addSubValue(JtxContract.JtxCategory.CONTENT_URI, contentValuesOf(
+                JtxContract.JtxCategory.TEXT to "updated-category"
+            ))
+        }
+        collection.updateJtxObject(id, updatedEntity)
+
+        val result = collection.getJtxObject(id)!!
+        assertEntitiesEqual(updatedEntity, result, onlyFieldsInExpected = true)
+    }
+
+    @Test
+    fun testUpdateJtxObject_viaBatch() {
+        val entity = sampleEntityWithSubValues("Original Title")
+        val id = collection.addJtxObject(entity)
+
+        val updatedEntity = Entity(ContentValues(entity.entityValues).apply {
+            put(JtxContract.JtxICalObject.SUMMARY, "Batch Updated Title")
+        }).apply {
+            addSubValue(JtxContract.JtxCategory.CONTENT_URI, contentValuesOf(
+                JtxContract.JtxCategory.TEXT to "batch-updated-category"
+            ))
+        }
+
+        val batch = JtxBatchOperation(client)
+        collection.updateJtxObject(id, updatedEntity, batch)
+        batch.commit()
+
+        val result = collection.getJtxObject(id)!!
+        assertEntitiesEqual(updatedEntity, result, onlyFieldsInExpected = true)
+    }
+
+    @Test
+    fun testUpdateJtxObjectRows() {
+        val id = collection.addJtxObject(sampleEntity("Original Title"))
+
+        collection.updateJtxObjectRows(
+            contentValuesOf(JtxContract.JtxICalObject.SUMMARY to "Bulk Updated"),
+            "${JtxContract.JtxICalObject.SUMMARY}=?",
+            arrayOf("Original Title")
+        )
+
+        assertEquals("Bulk Updated", collection.getJtxObject(id)!!.entityValues.getAsString(JtxContract.JtxICalObject.SUMMARY))
+    }
+
+    @Test
+    fun testDeleteJtxObject() {
+        val id = collection.addJtxObject(sampleEntity())
+        assertNotNull(collection.getJtxObject(id))
+
+        collection.deleteJtxObject(id)
+        assertNull(collection.getJtxObject(id))
+    }
+
+    @Test
+    fun testDeleteJtxObject_viaBatch() {
+        val id = collection.addJtxObject(sampleEntity())
+        assertNotNull(collection.getJtxObject(id))
+
+        val batch = JtxBatchOperation(client)
+        collection.deleteJtxObject(id, batch)
+        batch.commit()
+
+        assertNull(collection.getJtxObject(id))
+    }
+
+    @Test
+    fun testDeleteJtxObject_cascadesSubRows() {
+        val entity = sampleEntityWithSubValues()
+        val id = collection.addJtxObject(entity)
+
+        // verify sub-row was created
+        val before = collection.getJtxObject(id)!!
+        assertEquals(1, before.subValues.size)
+
+        collection.deleteJtxObject(id)
+
+        // object is gone
+        assertNull(collection.getJtxObject(id))
+
+        // verify category sub-row was cascade-deleted by the provider
+        val remainingCategories = client.query(
+                JtxContract.JtxCategory.CONTENT_URI.asSyncAdapter(testAccount),
+                arrayOf(JtxContract.JtxCategory.ID),
+                "${JtxContract.JtxCategory.ICALOBJECT_ID}=?",
+                arrayOf(id.toString()),
+                null
+            )?.use { it.count } ?: 0
+        assertEquals(0, remainingCategories)
+    }
+
+    @Test
+    fun testCountJtxObjects_isolatedToCollection() {
+        val otherCollection = provider.createAndGetCollection(contentValuesOf(
+            JtxContract.JtxCollection.URL to "https://example.com/other",
+            JtxContract.JtxCollection.DISPLAYNAME to "Other Collection",
+            JtxContract.JtxCollection.SUPPORTSVTODO to true
+        ))
+        try {
+            // object in other collection
+            otherCollection.addJtxObject(Entity(contentValuesOf(
+                JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID to otherCollection.id,
+                JtxContract.JtxICalObject.COMPONENT to Component.VTODO.name,
+                JtxContract.JtxICalObject.SUMMARY to "Other Object"
+            )))
+
+            // object in our collection
+            collection.addJtxObject(sampleEntity())
+
+            assertEquals(1, collection.countJtxObjects(null, null))
+            assertEquals(1, otherCollection.countJtxObjects(null, null))
+        } finally {
+            otherCollection.delete()
+        }
+    }
+
+}

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -115,7 +115,7 @@ class JtxCollection(
         val objectRowIdx = batch.nextBackrefIdx()
         batch += CpoBuilder.newInsert(jtxObjectsUri).withValues(entity.entityValues)
 
-        // insert data rows (with reference to event row ID)
+        // insert data rows (with reference to jtx object ID)
         for (subValue in entity.subValues)
             batch += CpoBuilder.newInsert(subValue.uri.asSyncAdapter(account))
                 .withValues(subValue.values)

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -6,13 +6,27 @@
 
 package at.bitfire.synctools.storage.jtx
 
+import android.content.ContentUris
 import android.content.ContentValues
+import android.content.Entity
+import android.net.Uri
+import android.os.RemoteException
+import androidx.annotation.VisibleForTesting
+import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
+import at.bitfire.synctools.storage.JtxBatchOperation
 import at.bitfire.synctools.storage.LocalStorageException
+import at.bitfire.synctools.storage.toContentValues
 import at.techbee.jtx.JtxContract
+import at.techbee.jtx.JtxContract.asSyncAdapter
+import java.util.LinkedList
 
 /**
  * Represents a locally stored jtx collection (journals, notes, tasks). Communicates with
  * the jtx Board content provider via [provider].
+ *
+ * Methods that use [ContentValues] operate directly on rows of the [JtxContract.JtxICalObject] table.
+ * Methods that use [Entity] operate on [JtxContract.JtxICalObject] rows together with
+ * associated sub-rows (attendees, categories, alarms, etc.).
  *
  * @param provider  jtx collection provider
  * @param values    content values as read from the jtx Board provider; [JtxContract.JtxCollection.ID] must be set
@@ -72,9 +86,387 @@ class JtxCollection(
                 || values.getAsString(JtxContract.JtxCollection.READONLY) == "true"
 
 
-    // CRUD Events
-    // TODO: Add JtxICalObject CRUD operations
-    // i.e. fun addJtxObject(entity: Entity): Long { ... }
+    // CRUD jtx collection objects (representing vtodo, vjournal)
+
+    /**
+     * Inserts a new jtx object into this collection.
+     *
+     * @param entity    object to insert
+     *
+     * @return ID of the newly inserted object
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun addJtxObject(entity: Entity): Long {
+        try {
+            val batch = JtxBatchOperation(client)
+            addJtxObject(entity, batch)
+            batch.commit()
+
+            val uri = batch.getResult(0)?.uri ?: throw LocalStorageException("Content provider returned null on insert")
+            return ContentUris.parseId(uri)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't insert jtx object", e)
+        }
+    }
+
+    fun addJtxObject(entity: Entity, batch: JtxBatchOperation) {
+        // insert jtx object row
+        val objectRowIdx = batch.nextBackrefIdx()
+        batch += CpoBuilder.newInsert(jtxObjectsUri).withValues(entity.entityValues)
+
+        // insert data rows (with reference to event row ID)
+        for (subValue in entity.subValues)
+            batch += CpoBuilder.newInsert(subValue.uri.asSyncAdapter(account))
+                .withValues(subValue.values)
+                .withValueBackReference(JtxContract.JtxAttendee.ICALOBJECT_ID, objectRowIdx)
+    }
+
+    /**
+     * Counts jtx objects in this collection that match the given selection criteria.
+     *
+     * @param where     selection
+     * @param whereArgs arguments for selection
+     *
+     * @return number of matching objects
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun countJtxObjects(where: String?, whereArgs: Array<String>?): Int {
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
+            client.query(jtxObjectsUri, arrayOf(JtxContract.JtxICalObject.ID),
+                protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+                return cursor.count
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't count jtx objects", e)
+        }
+        return 0
+    }
+
+    /**
+     * Gets the first object from this jtx collection that matches the given query.
+     *
+     * Adds a WHERE clause that restricts the query to [JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID] = [id].
+     *
+     * @param where     selection
+     * @param whereArgs arguments for selection
+     * @param sortOrder sort order
+     *
+     * @return first jtx object entity from this collection that matches the selection, or `null` if none found
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun findJtxObject(where: String?, whereArgs: Array<String>?, sortOrder: String? = null): Entity? {
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
+            client.query(jtxObjectsUri, null, protectedWhere, protectedWhereArgs, sortOrder)?.use { cursor ->
+                if (cursor.moveToNext())
+                    return readEntity(cursor.toContentValues())
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query jtx objects", e)
+        }
+        return null
+    }
+
+    /**
+     * Queries jtx objects from this jtx collection.
+     *
+     * Adds a WHERE clause that restricts the query to [JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID] = [id].
+     *
+     * @param where     selection
+     * @param whereArgs arguments for selection
+     *
+     * @return jtx object entities from this collection which match the selection
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun findJtxObjects(where: String?, whereArgs: Array<String>?): List<Entity> {
+        val entities = LinkedList<Entity>()
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
+            client.query(jtxObjectsUri, null, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+                while (cursor.moveToNext())
+                    entities += readEntity(cursor.toContentValues())
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query jtx objects", e)
+        }
+        return entities
+    }
+
+    /**
+     * Gets the first jtx object row (without sub-rows) that matches the given query.
+     *
+     * Adds a WHERE clause that restricts the query to [JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID] = [id].
+     *
+     * @param projection    requested fields
+     * @param where         selection
+     * @param whereArgs     arguments for selection
+     *
+     * @return first matching jtx object row as [ContentValues], or `null` if none found
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun findJtxObjectRow(projection: Array<String>?, where: String?, whereArgs: Array<String>?): ContentValues? {
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
+            client.query(jtxObjectsUri, projection, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+                if (cursor.moveToNext())
+                    return cursor.toContentValues()
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query jtx object rows", e)
+        }
+        return null
+    }
+
+    /**
+     * Gets a specific jtx object, identified by its ID, from this collection.
+     *
+     * @param id    jtx object ID
+     *
+     * @return object entity (or `null` if not found)
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun getJtxObject(id: Long): Entity? {
+        try {
+            client.query(jtxObjectUri(id), null, null, null, null)?.use { cursor ->
+                if (cursor.moveToNext())
+                    return readEntity(cursor.toContentValues())
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query jtx object entity", e)
+        }
+        return null
+    }
+
+    /**
+     * Gets the main row of a specific jtx object, identified by its ID, from this collection.
+     *
+     * @param id            jtx object ID
+     * @param projection    requested fields
+     * @param where         optional additional selection
+     * @param whereArgs     arguments for additional selection
+     *
+     * @return jtx object main row (or `null` if not found)
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun getJtxObjectRow(id: Long, projection: Array<String>? = null, where: String? = null, whereArgs: Array<String>? = null): ContentValues? {
+        try {
+            client.query(jtxObjectUri(id), projection, where, whereArgs, null)?.use { cursor ->
+                if (cursor.moveToNext())
+                    return cursor.toContentValues()
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query jtx object row", e)
+        }
+        return null
+    }
+
+    /**
+     * Iterates jtx object rows (without sub-rows) from this collection.
+     *
+     * Adds a WHERE clause that restricts the query to [JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID] = [id].
+     *
+     * @param projection    requested fields
+     * @param where         selection
+     * @param whereArgs     arguments for selection
+     * @param body          callback that is called for each main row
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun iterateJtxObjectRows(projection: Array<String>?, where: String?, whereArgs: Array<String>?, body: (ContentValues) -> Unit) {
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
+            client.query(jtxObjectsUri, projection, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+                while (cursor.moveToNext())
+                    body(cursor.toContentValues())
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't iterate jtx object rows", e)
+        }
+    }
+
+    /**
+     * Iterates jtx objects (with sub-rows) from this collection.
+     *
+     * Adds a WHERE clause that restricts the query to [JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID] = [id].
+     *
+     * @param where         selection
+     * @param whereArgs     arguments for selection
+     * @param body          callback that is called for each jtx object entity
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun iterateJtxObjects(where: String?, whereArgs: Array<String>?, body: (Entity) -> Unit) {
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
+            client.query(jtxObjectsUri, null, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+                while (cursor.moveToNext())
+                    body(readEntity(cursor.toContentValues()))
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't iterate jtx objects", e)
+        }
+    }
+
+    /**
+     * Updates a specific jtx object's main row with the given values. Doesn't influence sub-rows.
+     *
+     * This method always uses the update method of the content provider and does not
+     * re-create rows, as it is required for some operations (see [updateJtxObject] for more
+     * information).
+     *
+     * @param id        jtx object ID
+     * @param values    new values
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun updateJtxObjectRow(id: Long, values: ContentValues) {
+        try {
+            client.update(jtxObjectUri(id), values, null, null)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't update jtx object row $id", e)
+        }
+    }
+
+    /**
+     * Updates a specific jtx object's main row with the given values. Doesn't influence sub-rows.
+     *
+     * This method always uses the update method of the content provider and does not
+     * re-create rows, as it is required for some operations (see [updateJtxObject] for more
+     * information).
+     *
+     * @param id        jtx object ID
+     * @param values    new values
+     * @param batch     batch operation in which the update is enqueued
+     */
+    fun updateJtxObjectRow(id: Long, values: ContentValues, batch: JtxBatchOperation) {
+        batch += CpoBuilder.newUpdate(jtxObjectUri(id))
+            .withValues(values)
+    }
+
+    /**
+     * Updates a jtx object's main row and refreshes all sub-rows.
+     *
+     * Sub-rows are always deleted and re-created from [entity].
+     *
+     * @param id        ID of the jtx object to update
+     * @param entity    new values of the jtx object
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun updateJtxObject(id: Long, entity: Entity) {
+        try {
+            val batch = JtxBatchOperation(client)
+            updateJtxObject(id, entity, batch)
+            batch.commit()
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't update jtx object $id", e)
+        }
+    }
+
+    /**
+     * Enqueues an update of a jtx object's main row and refreshes all sub-rows into [batch].
+     *
+     * Sub-rows are always deleted and re-created from [entity].
+     *
+     * @param id        ID of the jtx object to update
+     * @param entity    new values of the jtx object
+     * @param batch     batch operation in which the update is enqueued
+     */
+    fun updateJtxObject(id: Long, entity: Entity, batch: JtxBatchOperation) {
+        // delete existing sub-rows
+        deleteDataRows(id, batch)
+
+        // update main row
+        val newValues = ContentValues(entity.entityValues).apply {
+            remove(JtxContract.JtxICalObject.ID)
+        }
+        batch += CpoBuilder.newUpdate(jtxObjectUri(id))
+            .withValues(newValues)
+
+        // insert new sub-rows
+        for (subValue in entity.subValues)
+            batch += CpoBuilder.newInsert(subValue.uri.asSyncAdapter(account))
+                .withValues(ContentValues(subValue.values).apply {
+                    put(ICALOBJECT_ID, id) // always keep reference to main row ID
+                })
+    }
+
+    /**
+     * Enqueues deletions of all known sub-rows for the given jtx object into [batch].
+     *
+     * @param objectId    ID of the jtx object whose sub-rows should be deleted
+     * @param batch     batch operation in which the deletions are enqueued
+     */
+    private fun deleteDataRows(objectId: Long, batch: JtxBatchOperation) {
+        val idStr = objectId.toString()
+        for (subUri in SUB_VALUE_URIS)
+            batch += CpoBuilder
+                .newDelete(subUri.asSyncAdapter(account))
+                .withSelection("$ICALOBJECT_ID=?", arrayOf(idStr))
+    }
+
+    /**
+     * Updates jtx object rows in this collection.
+     *
+     * Adds a WHERE clause that restricts the query to [JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID] = [id].
+     *
+     * @param values    values to update
+     * @param where     selection
+     * @param whereArgs arguments for selection
+     *
+     * @return number of updated rows
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun updateJtxObjectRows(values: ContentValues, where: String?, whereArgs: Array<String>?): Int =
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
+            client.update(jtxObjectsUri, values, protectedWhere, protectedWhereArgs)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't update jtx objects", e)
+        }
+
+    /**
+     * Deletes all jtx objects of this collection from the local storage.
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    @VisibleForTesting
+    fun deleteAllJtxObjects() {
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(null, null)
+            client.delete(jtxObjectsUri, protectedWhere, protectedWhereArgs)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't delete all jtx objects from collection", e)
+        }
+    }
+
+    /**
+     * Deletes a jtx object row. The jtx Board provider automatically deletes associated sub-rows.
+     *
+     * @param id    ID of the jtx object
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
+    fun deleteJtxObject(id: Long) {
+        try {
+            client.delete(jtxObjectUri(id), null, null)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't delete jtx object $id", e)
+        }
+    }
+
+    internal fun deleteJtxObject(id: Long, batch: JtxBatchOperation) {
+        batch += CpoBuilder.newDelete(jtxObjectUri(id))
+    }
 
 
     // shortcuts to upper level
@@ -97,5 +489,90 @@ class JtxCollection(
      */
     fun update(values: ContentValues): Int =
         provider.updateCollection(id, values)
+
+
+    // helpers
+
+    val account
+        get() = provider.account
+
+    val client
+        get() = provider.client
+
+    val jtxObjectsUri
+        get() = JtxContract.JtxICalObject.CONTENT_URI.asSyncAdapter(account)
+
+    fun jtxObjectUri(id: Long): Uri =
+        ContentUris.withAppendedId(jtxObjectsUri, id)
+
+    /**
+     * Restricts a given selection/where clause to this collection ID.
+     *
+     * @param where     selection
+     * @param whereArgs arguments for selection
+     *
+     * @return restricted selection and arguments
+     */
+    private fun whereWithCollectionId(where: String?, whereArgs: Array<String>?): Pair<String, Array<String>> {
+        val protectedWhere = "(${where ?: "1"}) AND ${JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID}=?"
+        val protectedWhereArgs = (whereArgs ?: arrayOf()) + id.toString()
+        return Pair(protectedWhere, protectedWhereArgs)
+    }
+
+    /**
+     * Builds an [Entity] from a main jtx object row by also querying all known sub-tables.
+     *
+     * @param mainValues    content values of the main [JtxContract.JtxICalObject] row
+     *
+     * @return entity combining the main row and all associated sub-rows
+     */
+    private fun readEntity(mainValues: ContentValues): Entity {
+        val entity = Entity(mainValues)
+        val objectId = mainValues.getAsLong(JtxContract.JtxICalObject.ID) ?: return entity
+
+        for (subUri in SUB_VALUE_URIS) {
+            try {
+                client.query(
+                    subUri.asSyncAdapter(account),
+                    null, "$ICALOBJECT_ID=?", arrayOf(objectId.toString()), null
+                )?.use { cursor ->
+                    while (cursor.moveToNext())
+                        entity.addSubValue(subUri, cursor.toContentValues())
+                }
+            } catch (e: RemoteException) {
+                throw LocalStorageException("Couldn't query jtx sub-rows from $subUri", e)
+            }
+        }
+
+        return entity
+    }
+
+    companion object {
+
+        /**
+         * Column name used in all jtx Board sub-tables to reference the parent [JtxContract.JtxICalObject] row.
+         *
+         * All sub-table contract objects define `ICALOBJECT_ID` with this same value.
+         */
+        internal const val ICALOBJECT_ID = "icalObjectId"
+
+        /**
+         * Content URIs of all known jtx Board sub-tables.
+         *
+         * Used to read sub-rows into [Entity] objects and to delete sub-rows on jtx object update.
+         */
+        internal val SUB_VALUE_URIS: List<Uri> = listOf(
+            JtxContract.JtxAttendee.CONTENT_URI,
+            JtxContract.JtxCategory.CONTENT_URI,
+            JtxContract.JtxComment.CONTENT_URI,
+            JtxContract.JtxOrganizer.CONTENT_URI,
+            JtxContract.JtxRelatedto.CONTENT_URI,
+            JtxContract.JtxResource.CONTENT_URI,
+            JtxContract.JtxAttachment.CONTENT_URI,
+            JtxContract.JtxAlarm.CONTENT_URI,
+            JtxContract.JtxUnknown.CONTENT_URI
+        )
+
+    }
 
 }

--- a/lib/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -119,7 +119,7 @@ class JtxCollection(
         for (subValue in entity.subValues)
             batch += CpoBuilder.newInsert(subValue.uri.asSyncAdapter(account))
                 .withValues(subValue.values)
-                .withValueBackReference(JtxContract.JtxAttendee.ICALOBJECT_ID, objectRowIdx)
+                .withValueBackReference(ICALOBJECT_ID, objectRowIdx)
     }
 
     /**


### PR DESCRIPTION
## Purpose
Add comprehensive create, read, update, and delete operations for managing JtxICalObject items (vtodo, vjournal) within jtx collections.

## Short description
- Add methods for inserting objects: `addJtxObject()` with batch support
- Add query methods: `countJtxObjects()`, `findJtxObject()`, `findJtxObjects()`, `getJtxObject()`, `getJtxObjectRow()`
- Add iteration methods: `iterateJtxObjects()`, `iterateJtxObjectRows()`
- Add update methods: `updateJtxObject()`, `updateJtxObjectRow()`, `updateJtxObjectRows()` with batch support
- Add delete methods: `deleteJtxObject()` with batch support and cascade deletion of sub-rows
- Properly handle Entity objects with sub-rows (attendees, categories, alarms, etc.)
- Include helper methods for batch operations and collection isolation
- Add comprehensive test coverage in `JtxCollectionTest.kt`

## Note
For reviewing it might be interesting to compare with `AndroidCalendar.kt`. Notice that the workaround for the calendarprovider bug addressed in `AndroidCalendar.kt` is of course not needed for JtxBoard.