### PR TITLE
[jtx] Add builder for start date, due date and duration

### DIFF
--- a/lib/src/main/kotlin/at/bitfire/synctools/icalendar/Ical4jHelpers.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/icalendar/Ical4jHelpers.kt
@@ -19,6 +19,7 @@ import net.fortuna.ical4j.model.component.CalendarComponent
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.DtEnd
 import net.fortuna.ical4j.model.property.DtStart
+import net.fortuna.ical4j.model.property.Due
 import net.fortuna.ical4j.model.property.RecurrenceId
 import net.fortuna.ical4j.model.property.Sequence
 import net.fortuna.ical4j.model.property.Uid
@@ -55,6 +56,10 @@ fun <T: Temporal> CalendarComponent.dtStart(): DtStart<T>? {
 
 fun <T: Temporal> CalendarComponent.dtEnd(): DtEnd<T>? {
     return getProperty<DtEnd<T>>(Property.DTEND).getOrNull()
+}
+
+fun <T: Temporal> CalendarComponent.due(): Due<T>? {
+    return getProperty<Due<T>>(Property.DUE).getOrNull()
 }
 
 fun <T: Temporal> VEvent.requireDtStart(): DtStart<T> =

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxItemBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxItemBuilder.kt
@@ -14,6 +14,7 @@ import at.bitfire.synctools.mapping.jtx.builder.DescriptionBuilder
 import at.bitfire.synctools.mapping.jtx.builder.JtxEntityBuilder
 import at.bitfire.synctools.mapping.jtx.builder.RecurrenceFieldsBuilder
 import at.bitfire.synctools.mapping.jtx.builder.SyncPropertiesBuilder
+import at.bitfire.synctools.mapping.jtx.builder.TimeFieldsBuilder
 import at.bitfire.synctools.storage.jtx.JtxItemAndExceptions
 import net.fortuna.ical4j.model.component.CalendarComponent
 import net.fortuna.ical4j.model.component.VJournal
@@ -35,7 +36,8 @@ class JtxItemBuilder(
         SyncPropertiesBuilder(fileName, eTag, scheduleTag, flags),
 
         DescriptionBuilder(),
-        RecurrenceFieldsBuilder()
+        RecurrenceFieldsBuilder(),
+        TimeFieldsBuilder()
     )
 
     fun build(component: AssociatedComponents<CalendarComponent>): JtxItemAndExceptions {

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/RecurrenceFieldsBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/RecurrenceFieldsBuilder.kt
@@ -10,24 +10,15 @@ import android.content.Entity
 import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
 import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDates
 import at.bitfire.synctools.icalendar.recurrenceId
+import at.bitfire.synctools.mapping.jtx.builder.TimeZoneIdMapper.toTimeZoneId
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import at.techbee.jtx.JtxContract
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.component.CalendarComponent
 import net.fortuna.ical4j.model.property.DateListProperty
 import net.fortuna.ical4j.model.property.RRule
-import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.temporal.Temporal
-import java.util.logging.Logger
 
 class RecurrenceFieldsBuilder : JtxEntityBuilder {
-
-    private val logger
-        get() = Logger.getLogger(javaClass.name)
 
     override fun build(from: CalendarComponent, main: CalendarComponent, to: Entity) {
         if (from === main) {
@@ -109,28 +100,7 @@ class RecurrenceFieldsBuilder : JtxEntityBuilder {
         }
 
         to.entityValues.put(JtxContract.JtxICalObject.RECURID, recurrenceId.value)
-        val timeZoneId = recurrenceId.normalizedDate().getTimeZoneId()
+        val timeZoneId = recurrenceId.normalizedDate().toTimeZoneId()
         to.entityValues.put(JtxContract.JtxICalObject.RECURID_TIMEZONE, timeZoneId)
-    }
-
-    private fun Temporal.getTimeZoneId(): String? = when (this) {
-        is ZonedDateTime -> {
-            this.zone.id
-        }
-        is Instant -> {
-            ZoneOffset.UTC.id
-        }
-        is LocalDateTime -> {
-            // Timezone unknown => floating time
-            null
-        }
-        is LocalDate -> {
-            // Without time, it is considered all-day
-            JtxContract.JtxICalObject.TZ_ALLDAY
-        }
-        else -> {
-            logger.warning("Ignoring unsupported temporal type: ${this::class}")
-            null
-        }
     }
 }

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeFieldsBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeFieldsBuilder.kt
@@ -1,0 +1,151 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.jtx.builder
+
+import android.content.Entity
+import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
+import at.bitfire.synctools.icalendar.dtStart
+import at.bitfire.synctools.icalendar.due
+import at.bitfire.synctools.mapping.jtx.builder.TimeZoneIdMapper.toTimeZoneId
+import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
+import at.techbee.jtx.JtxContract
+import at.techbee.jtx.JtxContract.JtxICalObject.TZ_ALLDAY
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.component.CalendarComponent
+import net.fortuna.ical4j.model.component.VJournal
+import net.fortuna.ical4j.model.component.VToDo
+import java.time.temporal.Temporal
+import java.util.logging.Logger
+
+/**
+ * Handles the iCalendar properties: DTSTART, DTEND, DUE, DURATION
+ */
+class TimeFieldsBuilder : JtxEntityBuilder {
+    private val logger
+        get() = Logger.getLogger(javaClass.name)
+
+    override fun build(from: CalendarComponent, main: CalendarComponent, to: Entity) {
+        if (from is VJournal) {
+            buildJournal(from, to)
+        } else if (from is VToDo) {
+            buildTask(from, to)
+        }
+    }
+
+    private fun buildJournal(from: VJournal, to: Entity) {
+        buildStartDate(from, to)
+
+        ignoreDtEnd(from, to)
+        ignoreDue(from, to)
+        ignoreDuration(from, to)
+    }
+
+    private fun buildTask(from: VToDo, to: Entity) {
+        val startTimeZoneId = buildStartDate(from, to)
+        val dueTimeZoneId = buildDueDate(from, to)
+        cleanUpTimeZones(startTimeZoneId, dueTimeZoneId, to)
+
+        warnIfDueDateAfterStartDate(from)
+
+        buildDuration(from, to)
+
+        ignoreDtEnd(from, to)
+    }
+
+    private fun buildStartDate(from: CalendarComponent, to: Entity): String? {
+        val start = from.dtStart<Temporal>()?.normalizedDate()
+        val timeZoneId = start?.toTimeZoneId()
+        if (start != null) {
+            to.entityValues.put(JtxContract.JtxICalObject.DTSTART, start.toTimestamp())
+            to.entityValues.put(JtxContract.JtxICalObject.DTSTART_TIMEZONE, timeZoneId)
+        } else {
+            to.entityValues.putNull(JtxContract.JtxICalObject.DTSTART)
+            to.entityValues.putNull(JtxContract.JtxICalObject.DTSTART_TIMEZONE)
+        }
+
+        return timeZoneId
+    }
+
+    private fun buildDueDate(from: CalendarComponent, to: Entity): String? {
+        val due = from.due<Temporal>()?.normalizedDate()
+        val timeZoneId = due?.toTimeZoneId()
+        if (due != null) {
+            to.entityValues.put(JtxContract.JtxICalObject.DUE, due.toTimestamp())
+            to.entityValues.put(JtxContract.JtxICalObject.DUE_TIMEZONE, timeZoneId)
+        } else {
+            to.entityValues.putNull(JtxContract.JtxICalObject.DUE)
+            to.entityValues.putNull(JtxContract.JtxICalObject.DUE_TIMEZONE)
+        }
+
+        return timeZoneId
+    }
+
+    private fun buildDuration(task: VToDo, to: Entity) {
+        val durationValue = task.duration?.value
+
+        if (durationValue != null && task.dtStart<Temporal>()?.date == null) {
+            logger.warning("Found DURATION without DTSTART in VTODO; ignoring DURATION")
+            to.entityValues.putNull(JtxContract.JtxICalObject.DURATION)
+        } else if (durationValue != null && task.due<Temporal>()?.date != null) {
+            logger.warning("Found DURATION and DTEND in VTODO; ignoring DURATION")
+            to.entityValues.putNull(JtxContract.JtxICalObject.DURATION)
+        } else if (durationValue != null) {
+            to.entityValues.put(JtxContract.JtxICalObject.DURATION, durationValue)
+        } else {
+            to.entityValues.putNull(JtxContract.JtxICalObject.DURATION)
+        }
+    }
+
+    private fun cleanUpTimeZones(startTimeZoneId: String?, dueTimeZoneId: String?, to: Entity) {
+        if (startTimeZoneId == TZ_ALLDAY && dueTimeZoneId != null && dueTimeZoneId != TZ_ALLDAY) {
+            logger.warning("DTSTART is DATE but DUE is DATE-TIME, rewriting DTSTART to DATE-TIME")
+            to.entityValues.put(JtxContract.JtxICalObject.DTSTART_TIMEZONE, dueTimeZoneId)
+        } else if (dueTimeZoneId == TZ_ALLDAY && startTimeZoneId != null && startTimeZoneId != TZ_ALLDAY) {
+            logger.warning("DTSTART is DATE-TIME but DUE is DATE, rewriting DUE to DATE-TIME")
+            to.entityValues.put(JtxContract.JtxICalObject.DUE_TIMEZONE, startTimeZoneId)
+        }
+    }
+
+    private fun warnIfDueDateAfterStartDate(task: VToDo) {
+        val start = task.dtStart<Temporal>()?.normalizedDate()?.toTimestamp()
+        val due = task.due<Temporal>()?.normalizedDate()?.toTimestamp()
+
+        // Previously DUE was dropped. Now reduced to a warning.
+        // See also: https://github.com/bitfireAT/ical4android/issues/70
+        if (start != null && due != null && due < start) {
+            logger.warning("Found invalid DUE < DTSTART")
+        }
+    }
+
+    private fun ignoreDtEnd(from: CalendarComponent, to: Entity) {
+        if (from.hasProperty(Property.DTEND)) {
+            logger.warning("DTEND must not be used with VJOURNAL, ignoring property.")
+        }
+
+        to.entityValues.putNull(JtxContract.JtxICalObject.DTEND)
+        to.entityValues.putNull(JtxContract.JtxICalObject.DTEND_TIMEZONE)
+    }
+
+    private fun ignoreDue(from: CalendarComponent, to: Entity) {
+        if (from.hasProperty(Property.DUE)) {
+            logger.warning("DUE must not be used with VJOURNAL, ignoring property.")
+        }
+
+        to.entityValues.putNull(JtxContract.JtxICalObject.DUE)
+        to.entityValues.putNull(JtxContract.JtxICalObject.DUE_TIMEZONE)
+    }
+
+    private fun ignoreDuration(from: CalendarComponent, to: Entity) {
+        if (from.hasProperty(Property.DURATION)) {
+            logger.warning("DURATION must not be used with VJOURNAL, ignoring property.")
+        }
+
+        to.entityValues.putNull(JtxContract.JtxICalObject.DURATION)
+    }
+}
+
+private fun CalendarComponent.hasProperty(name: String) = getProperty<Property>(name).isPresent

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeFieldsBuilder.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeFieldsBuilder.kt
@@ -91,7 +91,7 @@ class TimeFieldsBuilder : JtxEntityBuilder {
             logger.warning("Found DURATION without DTSTART in VTODO; ignoring DURATION")
             to.entityValues.putNull(JtxContract.JtxICalObject.DURATION)
         } else if (durationValue != null && task.due<Temporal>()?.date != null) {
-            logger.warning("Found DURATION and DTEND in VTODO; ignoring DURATION")
+            logger.warning("Found DURATION and DUE in VTODO; ignoring DURATION")
             to.entityValues.putNull(JtxContract.JtxICalObject.DURATION)
         } else if (durationValue != null) {
             to.entityValues.put(JtxContract.JtxICalObject.DURATION, durationValue)

--- a/lib/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeZoneIdMapper.kt
+++ b/lib/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeZoneIdMapper.kt
@@ -1,0 +1,44 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.jtx.builder
+
+import at.techbee.jtx.JtxContract
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.Temporal
+import java.util.logging.Logger
+
+object TimeZoneIdMapper {
+    private val logger
+        get() = Logger.getLogger(javaClass.name)
+
+    fun Temporal.toTimeZoneId(): String? {
+        return when (this) {
+            is ZonedDateTime -> {
+                this.zone.id
+            }
+            is Instant -> {
+                ZoneOffset.UTC.id
+            }
+            is LocalDateTime -> {
+                // Timezone unknown => floating time
+                null
+            }
+            is LocalDate -> {
+                // Without time, it is considered all-day
+                JtxContract.JtxICalObject.TZ_ALLDAY
+            }
+            else -> {
+                logger.warning("Ignoring unsupported temporal type: ${this::class}")
+                null
+            }
+        }
+    }
+}

--- a/lib/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeFieldsBuilderTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeFieldsBuilderTest.kt
@@ -1,0 +1,241 @@
+/*
+ * This file is part of bitfireAT/synctools which is released under GPLv3.
+ * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package at.bitfire.synctools.mapping.jtx.builder
+
+import android.content.ContentValues
+import android.content.Entity
+import androidx.core.content.contentValuesOf
+import at.bitfire.dateTimeValue
+import at.bitfire.dateValue
+import at.bitfire.synctools.icalendar.plusAssign
+import at.bitfire.synctools.test.assertContentValuesEqual
+import at.techbee.jtx.JtxContract
+import net.fortuna.ical4j.model.TimeZoneRegistryFactory
+import net.fortuna.ical4j.model.component.VJournal
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.DtEnd
+import net.fortuna.ical4j.model.property.DtStart
+import net.fortuna.ical4j.model.property.Due
+import net.fortuna.ical4j.model.property.Duration
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TimeFieldsBuilderTest {
+
+    private val tzRegistry = TimeZoneRegistryFactory.getInstance().createRegistry()
+    private val tzVienna = tzRegistry.getTimeZone("Europe/Vienna")
+
+    private val builder = TimeFieldsBuilder()
+
+    @Test
+    fun `VJOURNAL with DTSTART`() {
+        val output = Entity(ContentValues())
+        val journal = VJournal().apply {
+            this += DtStart(dateTimeValue("20260518T120000Z"))
+        }
+
+        builder.build(from = journal, main = journal, output)
+
+        assertContentValuesEqual(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to 1779105600000L,
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "Z",
+                JtxContract.JtxICalObject.DTEND to null,
+                JtxContract.JtxICalObject.DTEND_TIMEZONE to null,
+                JtxContract.JtxICalObject.DUE to null,
+                JtxContract.JtxICalObject.DUE_TIMEZONE to null,
+                JtxContract.JtxICalObject.DURATION to null
+            ),
+            output.entityValues
+        )
+    }
+
+    @Test
+    fun `VJOURNAL without DTSTART`() {
+        val output = Entity(ContentValues())
+        val journal = VJournal()
+
+        builder.build(from = journal, main = journal, output)
+
+        assertContentValuesEqual(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to null,
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to null,
+                JtxContract.JtxICalObject.DTEND to null,
+                JtxContract.JtxICalObject.DTEND_TIMEZONE to null,
+                JtxContract.JtxICalObject.DUE to null,
+                JtxContract.JtxICalObject.DUE_TIMEZONE to null,
+                JtxContract.JtxICalObject.DURATION to null
+            ),
+            output.entityValues
+        )
+    }
+
+    @Test
+    fun `VJOURNAL with DTEND, DUE, and DURATION should ignore properties`() {
+        val output = Entity(ContentValues())
+        val journal = VJournal().apply {
+            this += DtStart(dateTimeValue("20260518T120000Z"))
+            this += DtEnd(dateTimeValue("20260518T140000Z"))
+            this += Due(dateTimeValue("20260518T140000Z"))
+            this += Duration("PT2H")
+        }
+
+        builder.build(from = journal, main = journal, output)
+
+        assertEquals(null, output.entityValues.getAsString(JtxContract.JtxICalObject.DTEND))
+        assertEquals(null, output.entityValues.getAsString(JtxContract.JtxICalObject.DTEND_TIMEZONE))
+        assertEquals(null, output.entityValues.getAsString(JtxContract.JtxICalObject.DUE))
+        assertEquals(null, output.entityValues.getAsString(JtxContract.JtxICalObject.DUE_TIMEZONE))
+        assertEquals(null, output.entityValues.getAsString(JtxContract.JtxICalObject.DURATION))
+    }
+
+    @Test
+    fun `VTODO with DTSTART`() {
+        val output = Entity(ContentValues())
+        val journal = VToDo().apply {
+            this += DtStart(dateTimeValue("20260518T120000Z"))
+        }
+
+        builder.build(from = journal, main = journal, output)
+
+        assertContentValuesEqual(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to 1779105600000L,
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "Z",
+                JtxContract.JtxICalObject.DTEND to null,
+                JtxContract.JtxICalObject.DTEND_TIMEZONE to null,
+                JtxContract.JtxICalObject.DUE to null,
+                JtxContract.JtxICalObject.DUE_TIMEZONE to null,
+                JtxContract.JtxICalObject.DURATION to null
+            ),
+            output.entityValues
+        )
+    }
+
+    @Test
+    fun `VTODO without DTSTART`() {
+        val output = Entity(ContentValues())
+        val journal = VToDo()
+
+        builder.build(from = journal, main = journal, output)
+
+        assertContentValuesEqual(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to null,
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to null,
+                JtxContract.JtxICalObject.DTEND to null,
+                JtxContract.JtxICalObject.DTEND_TIMEZONE to null,
+                JtxContract.JtxICalObject.DUE to null,
+                JtxContract.JtxICalObject.DUE_TIMEZONE to null,
+                JtxContract.JtxICalObject.DURATION to null
+            ),
+            output.entityValues
+        )
+    }
+
+    @Test
+    fun `VTODO with DTSTART using DATE-TIME and DUE using DATE`() {
+        val output = Entity(ContentValues())
+        val journal = VToDo().apply {
+            this += DtStart(dateTimeValue("20260518T120000", tzVienna))
+            this += Due(dateValue("20260520"))
+        }
+
+        builder.build(from = journal, main = journal, output)
+
+        assertContentValuesEqual(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to 1779098400000L,
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "Europe/Vienna",
+                JtxContract.JtxICalObject.DTEND to null,
+                JtxContract.JtxICalObject.DTEND_TIMEZONE to null,
+                JtxContract.JtxICalObject.DUE to 1779235200000L,
+                JtxContract.JtxICalObject.DUE_TIMEZONE to "Europe/Vienna",
+                JtxContract.JtxICalObject.DURATION to null
+            ),
+            output.entityValues
+        )
+    }
+
+    @Test
+    fun `VTODO with DTSTART using DATE and DUE using DATE-TIME`() {
+        val output = Entity(ContentValues())
+        val journal = VToDo().apply {
+            this += DtStart(dateValue("20260518"))
+            this += Due(dateTimeValue("20260520T120000", tzVienna))
+        }
+
+        builder.build(from = journal, main = journal, output)
+
+        assertContentValuesEqual(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to 1779062400000L,
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "Europe/Vienna",
+                JtxContract.JtxICalObject.DTEND to null,
+                JtxContract.JtxICalObject.DTEND_TIMEZONE to null,
+                JtxContract.JtxICalObject.DUE to 1779271200000L,
+                JtxContract.JtxICalObject.DUE_TIMEZONE to "Europe/Vienna",
+                JtxContract.JtxICalObject.DURATION to null
+            ),
+            output.entityValues
+        )
+    }
+
+    @Test
+    fun `VTODO with DTSTART and DURATION`() {
+        val output = Entity(ContentValues())
+        val journal = VToDo().apply {
+            this += DtStart(dateTimeValue("20260518T120000", tzVienna))
+            this += Duration("P1D")
+        }
+
+        builder.build(from = journal, main = journal, output)
+
+        assertContentValuesEqual(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to 1779098400000L,
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "Europe/Vienna",
+                JtxContract.JtxICalObject.DTEND to null,
+                JtxContract.JtxICalObject.DTEND_TIMEZONE to null,
+                JtxContract.JtxICalObject.DUE to null,
+                JtxContract.JtxICalObject.DUE_TIMEZONE to null,
+                JtxContract.JtxICalObject.DURATION to "P1D"
+            ),
+            output.entityValues
+        )
+    }
+
+    @Test
+    fun `VTODO with DURATION and without DTSTART should ignore DURATION`() {
+        val output = Entity(ContentValues())
+        val journal = VToDo().apply {
+            this += Duration("P1D")
+        }
+
+        builder.build(from = journal, main = journal, output)
+
+        assertEquals(null, output.entityValues.getAsString(JtxContract.JtxICalObject.DURATION))
+    }
+
+    @Test
+    fun `VTODO with DURATION and DUE should ignore DURATION`() {
+        val output = Entity(ContentValues())
+        val journal = VToDo().apply {
+            this += DtStart(dateTimeValue("20260518T100000Z"))
+            this += Due(dateTimeValue("20260518T120000Z"))
+            this += Duration("P1D")
+        }
+
+        builder.build(from = journal, main = journal, output)
+
+        assertEquals(null, output.entityValues.getAsString(JtxContract.JtxICalObject.DURATION))
+    }
+}


### PR DESCRIPTION
Adds `TimeFieldsBuilder` that handles the iCalendar properties: `DTSTART`, `DTEND`, `DUE`, `DURATION`.